### PR TITLE
Improve participant joining and sync connectivity

### DIFF
--- a/services/syncService.ts
+++ b/services/syncService.ts
@@ -22,8 +22,10 @@ class SyncService {
       return this.connectionPromise;
     }
 
-    // Connect to the same host
-    const url = window.location.origin;
+    // Connect to the sync server (supports separate dev server on port 3000)
+    const envUrl = (import.meta as any)?.env?.VITE_SYNC_SERVER_URL as string | undefined;
+    const isViteDev = window.location.port === '5173';
+    const url = envUrl || (isViteDev ? 'http://localhost:3000' : window.location.origin);
     console.log('[SyncService] Connecting to:', url);
 
     this.socket = io(url, {


### PR DESCRIPTION
## Summary
- auto-route participants (especially via invitations) straight into the active retrospective instead of the dashboard
- ensure participant reloads restore directly into an in-progress session when applicable
- make the sync service connect to a configurable backend URL, defaulting to the dev server port when using Vite

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693abf4f62148327b07f6b66cf1869b9)