### PR TITLE
Fix sync connection sequencing for participants

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -49,8 +49,18 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // Connect to sync service on mount
   useEffect(() => {
-    syncService.connect();
-    syncService.joinSession(sessionId, currentUser.id, currentUser.name);
+    let isMounted = true;
+
+    (async () => {
+      try {
+        await syncService.connect();
+        if (isMounted) {
+          syncService.joinSession(sessionId, currentUser.id, currentUser.name);
+        }
+      } catch (e) {
+        console.error('[Session] Failed to connect to sync service', e);
+      }
+    })();
 
     // Listen for session updates from other clients
     const unsubUpdate = syncService.onSessionUpdate((updatedSession) => {
@@ -82,6 +92,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
       unsubJoin();
       unsubLeave();
       syncService.leaveSession();
+      isMounted = false;
     };
   }, [sessionId, currentUser.id, currentUser.name, currentUser.role, team.id]);
 

--- a/services/syncService.ts
+++ b/services/syncService.ts
@@ -12,6 +12,7 @@ class SyncService {
   private currentSessionId: string | null = null;
   private pendingJoin: { sessionId: string; userId: string; userName: string } | null = null;
   private connectionPromise: Promise<void> | null = null;
+  private queuedSession: RetroSession | null = null;
 
   connect(): Promise<void> {
     if (this.socket?.connected) {
@@ -22,8 +23,10 @@ class SyncService {
       return this.connectionPromise;
     }
 
-    // Connect to the same host
-    const url = window.location.origin;
+    // Connect to the sync server (supports separate dev server on port 3000)
+    const envUrl = (import.meta as any)?.env?.VITE_SYNC_SERVER_URL as string | undefined;
+    const isViteDev = window.location.port === '5173';
+    const url = envUrl || (isViteDev ? 'http://localhost:3000' : window.location.origin);
     console.log('[SyncService] Connecting to:', url);
 
     this.socket = io(url, {
@@ -42,6 +45,13 @@ class SyncService {
           console.log('[SyncService] Processing pending join:', this.pendingJoin);
           this.socket!.emit('join-session', this.pendingJoin);
           this.pendingJoin = null;
+        }
+
+        // Flush any queued session update
+        if (this.queuedSession) {
+          console.log('[SyncService] Flushing queued session update');
+          this.socket!.emit('update-session', this.queuedSession);
+          this.queuedSession = null;
         }
 
         resolve();
@@ -92,10 +102,13 @@ class SyncService {
     if (this.socket?.connected) {
       console.log('[SyncService] Emitting join-session:', joinData);
       this.socket.emit('join-session', joinData);
-    } else {
-      console.log('[SyncService] Socket not connected, queuing join:', joinData);
-      this.pendingJoin = joinData;
+      return;
     }
+
+    console.log('[SyncService] Socket not connected, queuing join:', joinData);
+    this.pendingJoin = joinData;
+    // Ensure a connection attempt is in flight
+    this.connect();
   }
 
   leaveSession() {
@@ -103,12 +116,17 @@ class SyncService {
   }
 
   updateSession(session: RetroSession) {
-    if (this.socket?.connected) {
-      console.log('[SyncService] Broadcasting session update, phase:', session.phase);
-      this.socket.emit('update-session', session);
-    } else {
-      console.warn('[SyncService] Cannot update session - not connected');
+    // If not connected yet, queue the latest session and ensure a connection attempt
+    if (!this.socket?.connected) {
+      console.warn('[SyncService] Cannot update session - not connected. Queuing update.');
+      this.queuedSession = session;
+      this.connect();
+      return;
     }
+
+    console.log('[SyncService] Broadcasting session update, phase:', session.phase);
+    this.queuedSession = null;
+    this.socket.emit('update-session', session);
   }
 
   onSessionUpdate(callback: SessionUpdateCallback) {


### PR DESCRIPTION
## Summary
- ensure session views wait for sync connection before joining rooms
- queue sync join and session updates when sockets connect late to keep participants aligned
- flush pending updates once connectivity is established

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693abf4f62148327b07f6b66cf1869b9)