### PR TITLE
Fix Express catch-all route for Express 5

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -49,8 +49,18 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // Connect to sync service on mount
   useEffect(() => {
-    syncService.connect();
-    syncService.joinSession(sessionId, currentUser.id, currentUser.name);
+    let isMounted = true;
+
+    (async () => {
+      try {
+        await syncService.connect();
+        if (isMounted) {
+          syncService.joinSession(sessionId, currentUser.id, currentUser.name);
+        }
+      } catch (e) {
+        console.error('[Session] Failed to connect to sync service', e);
+      }
+    })();
 
     // Listen for session updates from other clients
     const unsubUpdate = syncService.onSessionUpdate((updatedSession) => {
@@ -82,6 +92,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
       unsubJoin();
       unsubLeave();
       syncService.leaveSession();
+      isMounted = false;
     };
   }, [sessionId, currentUser.id, currentUser.name, currentUser.role, team.id]);
 

--- a/railway.toml
+++ b/railway.toml
@@ -7,9 +7,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-# Start command (nginx is started in Dockerfile CMD)
-# Uncomment below if using Nixpacks instead of Docker
-# startCommand = "npm run preview"
+# Runtime started by Docker CMD (node server.js) to serve API + WebSockets
 
 # Health check
 healthcheckPath = "/health"

--- a/server.js
+++ b/server.js
@@ -10,11 +10,17 @@ const __dirname = dirname(__filename);
 const app = express();
 const server = createServer(app);
 const io = new Server(server, {
+  // Explicit path avoids collisions with platform proxies
+  path: '/socket.io',
   cors: {
     origin: "*",
     methods: ["GET", "POST"]
   }
 });
+
+// Health endpoints for platform monitoring
+app.get('/health', (_req, res) => res.status(200).send('OK'));
+app.get('/ready', (_req, res) => res.status(200).send('READY'));
 
 // Serve static files from dist folder
 app.use(express.static(join(__dirname, 'dist')));
@@ -97,7 +103,8 @@ io.on('connection', (socket) => {
 });
 
 // Handle SPA routing - serve index.html for all non-API routes
-app.get('*', (req, res) => {
+// Use a regex catch-all compatible with Express 5's path-to-regexp
+app.get(/.*/, (req, res) => {
   res.sendFile(join(__dirname, 'dist', 'index.html'));
 });
 


### PR DESCRIPTION
## Summary
- replace the SPA catch-all route with an Express 5 compatible regex to prevent startup crashes
- keep health checks responsive so Railway can mark the container healthy

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693abf4f62148327b07f6b66cf1869b9)