### PR TITLE
Add new retro templates, anonymity, and email invites

### DIFF
--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Team, RetroSession } from '../types';
+import { dataService } from '../services/dataService';
 
 interface Props {
   team: Team;
@@ -9,6 +10,12 @@ interface Props {
 }
 
 const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }) => {
+  const [inviteeName, setInviteeName] = useState('');
+  const [inviteeEmail, setInviteeEmail] = useState('');
+  const [generatedLink, setGeneratedLink] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+
   // Encode essential team data for invitation (id, name, password)
   // Also include active session data if available
   const inviteData: {
@@ -26,6 +33,45 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
   const encodedData = btoa(unescape(encodeURIComponent(JSON.stringify(inviteData))));
   const link = `${window.location.origin}?join=${encodedData}`;
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(link)}`;
+
+  const handlePersonalInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteeEmail.trim()) return;
+
+    try {
+      setStatus('sending');
+      setStatusMessage('Sending email invite…');
+      const { inviteLink } = dataService.createMemberInvite(team.id, inviteeName.trim(), inviteeEmail.trim(), activeSession?.id);
+      setGeneratedLink(inviteLink);
+
+      try {
+        const res = await fetch('/api/send-invite', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: inviteeEmail.trim(),
+            name: inviteeName.trim() || inviteeEmail.trim(),
+            link: inviteLink,
+            teamName: team.name,
+            sessionName: activeSession?.name,
+          })
+        });
+
+        if (!res.ok) {
+          throw new Error('Email service not configured');
+        }
+
+        setStatus('sent');
+        setStatusMessage('Invitation sent by email.');
+      } catch (err: any) {
+        setStatus('error');
+        setStatusMessage(err.message || 'Unable to send email. Copy the link instead.');
+      }
+    } catch (err: any) {
+      setStatus('error');
+      setStatusMessage(err.message || 'Failed to generate invite');
+    }
+  };
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-sm">
@@ -48,7 +94,7 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
 
         <div className="bg-slate-50 p-3 rounded-lg border border-slate-200 flex items-center justify-between mb-4">
             <code className="text-xs text-slate-600 truncate mr-2">{link}</code>
-            <button 
+            <button
                 onClick={() => navigator.clipboard.writeText(link)}
                 className="text-retro-primary font-bold text-xs hover:underline"
             >
@@ -56,10 +102,63 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
             </button>
         </div>
 
+        <form onSubmit={handlePersonalInvite} className="mb-4 space-y-3 border-t border-slate-100 pt-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-bold text-slate-700">Invite by email</p>
+              <p className="text-xs text-slate-500">Send a unique link tied to an email.</p>
+            </div>
+            {status !== 'idle' && (
+              <span className={`text-xs font-bold ${status === 'sent' ? 'text-emerald-600' : status === 'sending' ? 'text-slate-500' : 'text-amber-600'}`}>
+                {statusMessage}
+              </span>
+            )}
+          </div>
+          <input
+            type="text"
+            placeholder="Name (optional)"
+            value={inviteeName}
+            onChange={(e) => setInviteeName(e.target.value)}
+            className="w-full border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
+          />
+          <div className="flex gap-2">
+            <input
+              type="email"
+              placeholder="email@example.com"
+              required
+              value={inviteeEmail}
+              onChange={(e) => setInviteeEmail(e.target.value)}
+              className="flex-1 border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
+            />
+            <button
+              type="submit"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-lg font-bold text-sm hover:bg-indigo-700 disabled:opacity-50"
+              disabled={!inviteeEmail.trim() || status === 'sending'}
+            >
+              {status === 'sending' ? 'Sending…' : 'Send invite'}
+            </button>
+          </div>
+        </form>
+
+        {generatedLink && (
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mb-4 text-sm text-emerald-700">
+            <div className="font-bold mb-1">Personal invite link</div>
+            <div className="flex items-center justify-between gap-2">
+              <code className="text-xs truncate flex-1">{generatedLink}</code>
+              <button
+                onClick={() => navigator.clipboard.writeText(generatedLink)}
+                className="text-emerald-700 font-bold text-xs hover:underline"
+              >
+                COPY
+              </button>
+            </div>
+          </div>
+        )}
+
         {onLogout && (
             <div className="mb-4 pt-4 border-t border-slate-100 text-center">
                 <p className="text-xs text-slate-400 mb-2">Want to test as another user?</p>
-                <button 
+                <button
                     onClick={onLogout}
                     className="text-indigo-600 text-sm font-bold hover:underline"
                 >

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -458,6 +458,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // --- Logic ---
   const handleExit = () => {
+      dataService.persistParticipants(team.id, getParticipants());
       if (session.phase !== 'CLOSE') {
           session.status = 'IN_PROGRESS';
       } else {

--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -12,6 +12,10 @@ export interface InviteData {
   members?: User[];
   globalActions?: ActionItem[];
   retrospectives?: RetroSession[];
+  memberId?: string;
+  memberEmail?: string;
+  memberName?: string;
+  inviteToken?: string;
 }
 
 interface Props {
@@ -42,6 +46,12 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
   useEffect(() => {
       setTeams(dataService.getAllTeams());
   }, [view]);
+
+  useEffect(() => {
+    if (inviteData?.memberName) {
+      setName(inviteData.memberName);
+    }
+  }, [inviteData]);
 
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
@@ -76,7 +86,12 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
       return;
     }
     try {
-      const { team, user } = dataService.joinTeamAsParticipant(selectedTeam.id, name.trim());
+      const { team, user } = dataService.joinTeamAsParticipant(
+        selectedTeam.id,
+        name.trim(),
+        inviteData?.memberEmail,
+        inviteData?.inviteToken
+      );
       if (onJoin) {
         onJoin(team, user);
       } else {
@@ -200,11 +215,17 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
                                 required
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 disabled:bg-slate-100 disabled:text-slate-500"
                                 placeholder="e.g. John Doe"
                                 autoFocus
+                                disabled={!!inviteData?.memberName && !!inviteData?.inviteToken}
                             />
                         </div>
+                        {inviteData?.memberEmail && (
+                          <div className="text-xs text-slate-500 bg-slate-100 border border-slate-200 rounded p-2">
+                            Joining as <strong>{inviteData.memberEmail}</strong>
+                          </div>
+                        )}
                         <button type="submit" className="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold hover:bg-indigo-700 shadow-lg">
                             Join Team
                         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^5.2.1",
+        "nodemailer": "^6.10.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "socket.io": "^4.8.1",
@@ -2546,6 +2547,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "express": "^5.2.1",
+    "nodemailer": "^6.10.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "socket.io": "^4.8.1",

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,8 @@ export interface User {
   name: string;
   color: string;
   role: Role;
+  email?: string;
+  inviteToken?: string;
 }
 
 export interface Column {


### PR DESCRIPTION
## Summary
- add more built-in retrospective templates and an anonymous mode toggle when starting a session
- allow facilitators to delete retrospectives while retaining their action items and persist participants back to the team roster
- add email-based guest invitations with per-user links using SMTP when configured on Railway

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403e59cf288327b3322f33db80b53a)