### PR TITLE
Add SMTP configuration guidance for email invites

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,21 @@ Si vous préférez ne pas utiliser Docker :
 
 Railway injecte automatiquement la variable `PORT`. Aucune configuration supplémentaire n'est requise.
 
+### Activer l'envoi d'emails (invitation par email)
+
+Pour que l'envoi d'invitations par email fonctionne sur Railway, ajoutez des variables d'environnement SMTP :
+
+1. Dans votre service Railway, ouvrez l'onglet **Variables**.
+2. Ajoutez :
+   - `SMTP_HOST` : nom d'hôte SMTP (ex. `smtp.gmail.com` ou hôte de votre provider)
+   - `SMTP_PORT` : port (587 par défaut)
+   - `SMTP_USER` et `SMTP_PASS` : identifiants SMTP
+   - `SMTP_SECURE=true` si votre fournisseur impose TLS explicite
+   - `FROM_EMAIL` (optionnel) si l'adresse d'expéditeur diffère de `SMTP_USER`
+3. Sauvegardez puis relancez le déploiement ; l'UI affichera que l'email est prêt dès que `SMTP_HOST` est détecté.
+
+Avec un provider type Mailtrap, vous pouvez copier les valeurs SMTP fournies par Mailtrap dans ces variables.
+
 ### Déploiement manuel via CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ En cas d'erreur `Connection timeout` / `ETIMEDOUT`, le host/port n'est pas joign
 - Ajustez les timeouts si besoin avec `SMTP_CONNECTION_TIMEOUT` / `SMTP_GREETING_TIMEOUT` / `SMTP_SOCKET_TIMEOUT` (en ms).
 - Si le provider impose TLS strict sur 465, activez `SMTP_SECURE=true`, mais privilégiez 587+STARTTLS quand c'est possible.
 
+Alternative recommandée si l'egress SMTP est filtré : déployez le template **Resend Railway SMTP Gateway** (https://railway.com/deploy/resend-railway-smtp-gateway). Ce service tourne dans Railway et expose des credentials SMTP atteignables ; copiez l'hôte/le port/l'utilisateur/le mot de passe fournis vers `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` (via Variables du service ou une Variable Set partagée), laissez `SMTP_SECURE=false` et utilisez STARTTLS sur 587 ou 2525.
+
 Avec un provider type Mailtrap, vous pouvez copier les valeurs SMTP fournies par Mailtrap dans ces variables.
 
 ### Déploiement manuel via CLI

--- a/README.md
+++ b/README.md
@@ -208,9 +208,10 @@ Pour que l'envoi d'invitations par email fonctionne sur Railway, ajoutez des var
 En cas d'erreur `Connection timeout` / `ETIMEDOUT`, le host/port n'est pas joignable depuis Railway :
 
 - Utilisez le bouton "Test SMTP" dans le modal d'invitation pour vérifier la connectivité en direct ; le message renvoyé contiendra le code d'erreur SMTP.
-- Essayez le port `587` avec STARTTLS (`SMTP_SECURE=false` ou vide) si votre provider le permet.
+- Évitez les ports 25 et 465 souvent bloqués en egress ; essayez le port `587` avec STARTTLS (`SMTP_SECURE=false` ou vide) ou `2525` selon votre provider.
 - Vérifiez les pare-feux / allowlists côté provider pour autoriser la sortie depuis Railway.
 - Ajustez les timeouts si besoin avec `SMTP_CONNECTION_TIMEOUT` / `SMTP_GREETING_TIMEOUT` / `SMTP_SOCKET_TIMEOUT` (en ms).
+- Si le provider impose TLS strict sur 465, activez `SMTP_SECURE=true`, mais privilégiez 587+STARTTLS quand c'est possible.
 
 Avec un provider type Mailtrap, vous pouvez copier les valeurs SMTP fournies par Mailtrap dans ces variables.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,21 @@ En cas d'erreur `Connection timeout` / `ETIMEDOUT`, le host/port n'est pas joign
 - Ajustez les timeouts si besoin avec `SMTP_CONNECTION_TIMEOUT` / `SMTP_GREETING_TIMEOUT` / `SMTP_SOCKET_TIMEOUT` (en ms).
 - Si le provider impose TLS strict sur 465, activez `SMTP_SECURE=true`, mais privilégiez 587+STARTTLS quand c'est possible.
 
-Alternative recommandée si l'egress SMTP est filtré : déployez le template **Resend Railway SMTP Gateway** (https://railway.com/deploy/resend-railway-smtp-gateway). Ce service tourne dans Railway et expose des credentials SMTP atteignables ; copiez l'hôte/le port/l'utilisateur/le mot de passe fournis vers `SMTP_HOST` / `SMTP_PORT` / `SMTP_USER` / `SMTP_PASS` (via Variables du service ou une Variable Set partagée), laissez `SMTP_SECURE=false` et utilisez STARTTLS sur 587 ou 2525.
+Alternative recommandée si l'egress SMTP est filtré : déployez le template **Resend Railway SMTP Gateway** (https://railway.com/deploy/resend-railway-smtp-gateway). Ce service tourne dans Railway et expose des credentials SMTP atteignables depuis l'app.
+
+Étapes pour l'utiliser :
+1. Cliquez sur "Deploy on Railway" depuis le template gateway et ajoutez la variable `RESEND_API_KEY` (clé API Resend). Le service démarre et affiche les variables `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`.
+2. Dans votre service **RetroGeminiCodex**, onglet **Variables**, ajoutez :
+   - `SMTP_HOST=${{resend-railway-gateway.SMTP_HOST}}`
+   - `SMTP_PORT=${{resend-railway-gateway.SMTP_PORT}}`
+   - `SMTP_USER=${{resend-railway-gateway.SMTP_USER}}`
+   - `SMTP_PASS=${{resend-railway-gateway.SMTP_PASS}}`
+   - (optionnel) `FROM_EMAIL` si l'expéditeur doit être différent.
+   Railway remplacera automatiquement ces références par les valeurs du service gateway ; redéployez pour prendre en compte.
+3. Laissez `SMTP_SECURE=false` et utilisez STARTTLS sur 587 ou 2525 (valeur par défaut déjà OK).
+4. Dans l'UI, utilisez le bouton « Test SMTP » : si la connexion réussit, les invitations fonctionneront via le gateway.
+
+Les variables `RESEND_SMTP_*`/`RAILWAY_SMTP_*` sont aussi reconnues automatiquement côté serveur si vous préférez les nommer ainsi.
 
 Avec un provider type Mailtrap, vous pouvez copier les valeurs SMTP fournies par Mailtrap dans ces variables.
 

--- a/README.md
+++ b/README.md
@@ -199,12 +199,15 @@ Pour que l'envoi d'invitations par email fonctionne sur Railway, ajoutez des var
    - `SMTP_HOST` : nom d'hôte SMTP (ex. `smtp.gmail.com` ou hôte de votre provider)
    - `SMTP_PORT` : port (587 par défaut)
    - `SMTP_USER` et `SMTP_PASS` : identifiants SMTP
-   - `SMTP_SECURE=true` si votre fournisseur impose TLS explicite
+   - `SMTP_SECURE=true` si votre fournisseur impose TLS explicite (défaut activé sur le port 465)
+   - `SMTP_REQUIRE_TLS=true` si le provider impose STARTTLS
+   - `SMTP_IGNORE_TLS=true` pour un provider qui refuse STARTTLS
    - `FROM_EMAIL` (optionnel) si l'adresse d'expéditeur diffère de `SMTP_USER`
 3. Sauvegardez puis relancez le déploiement ; l'UI affichera que l'email est prêt dès que `SMTP_HOST` est détecté.
 
 En cas d'erreur `Connection timeout` / `ETIMEDOUT`, le host/port n'est pas joignable depuis Railway :
 
+- Utilisez le bouton "Test SMTP" dans le modal d'invitation pour vérifier la connectivité en direct ; le message renvoyé contiendra le code d'erreur SMTP.
 - Essayez le port `587` avec STARTTLS (`SMTP_SECURE=false` ou vide) si votre provider le permet.
 - Vérifiez les pare-feux / allowlists côté provider pour autoriser la sortie depuis Railway.
 - Ajustez les timeouts si besoin avec `SMTP_CONNECTION_TIMEOUT` / `SMTP_GREETING_TIMEOUT` / `SMTP_SOCKET_TIMEOUT` (en ms).

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ Si vous préférez ne pas utiliser Docker :
 
 Railway injecte automatiquement la variable `PORT`. Aucune configuration supplémentaire n'est requise.
 
+Pour la persistance des données (teams, actions, etc.), spécifiez un chemin en écriture via une variable d'environnement si le dossier de l'application est en lecture seule :
+
+- `DATA_FILE_PATH=/data/data.json` (recommandé avec un volume Railway monté sur `/data`)
+- ou `DATA_DIR=/tmp` pour utiliser un dossier temporaire (non persistant).
+
 ### Activer l'envoi d'emails (invitation par email)
 
 Pour que l'envoi d'invitations par email fonctionne sur Railway, ajoutez des variables d'environnement SMTP :

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Alternative recommandée si l'egress SMTP est filtré : déployez le template **
    - `SMTP_PASS=${{resend-railway-gateway.SMTP_PASS}}`
    - (optionnel) `FROM_EMAIL` si l'expéditeur doit être différent.
    Railway remplacera automatiquement ces références par les valeurs du service gateway ; redéployez pour prendre en compte.
+   - Assurez-vous que le nom du service (`resend-railway-gateway` dans l'exemple) correspond exactement à votre service gateway. Si le UI affiche encore des références du type `${{service.SMTP_HOST}}`, c'est que la variable n'a pas été résolue (nom/service ou guillemets incorrects).
 3. Laissez `SMTP_SECURE=false` et utilisez STARTTLS sur 587 ou 2525 (valeur par défaut déjà OK).
 4. Dans l'UI, utilisez le bouton « Test SMTP » : si la connexion réussit, les invitations fonctionneront via le gateway.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ Pour que l'envoi d'invitations par email fonctionne sur Railway, ajoutez des var
    - `FROM_EMAIL` (optionnel) si l'adresse d'expéditeur diffère de `SMTP_USER`
 3. Sauvegardez puis relancez le déploiement ; l'UI affichera que l'email est prêt dès que `SMTP_HOST` est détecté.
 
+En cas d'erreur `Connection timeout` / `ETIMEDOUT`, le host/port n'est pas joignable depuis Railway :
+
+- Essayez le port `587` avec STARTTLS (`SMTP_SECURE=false` ou vide) si votre provider le permet.
+- Vérifiez les pare-feux / allowlists côté provider pour autoriser la sortie depuis Railway.
+- Ajustez les timeouts si besoin avec `SMTP_CONNECTION_TIMEOUT` / `SMTP_GREETING_TIMEOUT` / `SMTP_SOCKET_TIMEOUT` (en ms).
+
 Avec un provider type Mailtrap, vous pouvez copier les valeurs SMTP fournies par Mailtrap dans ces variables.
 
 ### Déploiement manuel via CLI

--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Team, RetroSession } from '../types';
+import { dataService } from '../services/dataService';
 
 interface Props {
   team: Team;
@@ -9,6 +10,14 @@ interface Props {
 }
 
 const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }) => {
+  const [inviteeName, setInviteeName] = useState('');
+  const [inviteeEmail, setInviteeEmail] = useState('');
+  const [generatedLink, setGeneratedLink] = useState('');
+  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [emailEnabled, setEmailEnabled] = useState<boolean | null>(null);
+  const [smtpHost, setSmtpHost] = useState('');
+
   // Encode essential team data for invitation (id, name, password)
   // Also include active session data if available
   const inviteData: {
@@ -26,6 +35,56 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
   const encodedData = btoa(unescape(encodeURIComponent(JSON.stringify(inviteData))));
   const link = `${window.location.origin}?join=${encodedData}`;
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(link)}`;
+
+  useEffect(() => {
+    // Check if the server has SMTP configured so we can guide the facilitator
+    fetch('/api/email-config')
+      .then((res) => res.json())
+      .then((cfg) => {
+        setEmailEnabled(!!cfg?.enabled);
+        setSmtpHost(cfg?.host || '');
+      })
+      .catch(() => setEmailEnabled(false));
+  }, []);
+
+  const handlePersonalInvite = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!inviteeEmail.trim()) return;
+
+    try {
+      setStatus('sending');
+      setStatusMessage('Sending email invite…');
+      const { inviteLink } = dataService.createMemberInvite(team.id, inviteeName.trim(), inviteeEmail.trim(), activeSession?.id);
+      setGeneratedLink(inviteLink);
+
+      try {
+        const res = await fetch('/api/send-invite', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            email: inviteeEmail.trim(),
+            name: inviteeName.trim() || inviteeEmail.trim(),
+            link: inviteLink,
+            teamName: team.name,
+            sessionName: activeSession?.name,
+          })
+        });
+
+        if (!res.ok) {
+          throw new Error('Email service not configured');
+        }
+
+        setStatus('sent');
+        setStatusMessage('Invitation sent by email.');
+      } catch (err: any) {
+        setStatus('error');
+        setStatusMessage(err.message || 'Unable to send email. Copy the link instead.');
+      }
+    } catch (err: any) {
+      setStatus('error');
+      setStatusMessage(err.message || 'Failed to generate invite');
+    }
+  };
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-sm">
@@ -48,7 +107,7 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
 
         <div className="bg-slate-50 p-3 rounded-lg border border-slate-200 flex items-center justify-between mb-4">
             <code className="text-xs text-slate-600 truncate mr-2">{link}</code>
-            <button 
+            <button
                 onClick={() => navigator.clipboard.writeText(link)}
                 className="text-retro-primary font-bold text-xs hover:underline"
             >
@@ -56,10 +115,81 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
             </button>
         </div>
 
+        <form onSubmit={handlePersonalInvite} className="mb-4 space-y-3 border-t border-slate-100 pt-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-bold text-slate-700">Invite by email</p>
+              <p className="text-xs text-slate-500">Send a unique link tied to an email.</p>
+              {emailEnabled === false && (
+                <p className="text-[11px] text-amber-600 font-semibold mt-1">
+                  Email service not configured. Add SMTP env vars in Railway to enable sending.
+                </p>
+              )}
+            </div>
+            {status !== 'idle' && (
+              <span className={`text-xs font-bold ${status === 'sent' ? 'text-emerald-600' : status === 'sending' ? 'text-slate-500' : 'text-amber-600'}`}>
+                {statusMessage}
+              </span>
+            )}
+          </div>
+          <input
+            type="text"
+            placeholder="Name (optional)"
+            value={inviteeName}
+            onChange={(e) => setInviteeName(e.target.value)}
+            className="w-full border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
+          />
+          <div className="flex gap-2">
+            <input
+              type="email"
+              placeholder="email@example.com"
+              required
+              value={inviteeEmail}
+              onChange={(e) => setInviteeEmail(e.target.value)}
+              className="flex-1 border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
+            />
+            <button
+              type="submit"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-lg font-bold text-sm hover:bg-indigo-700 disabled:opacity-50"
+              disabled={!inviteeEmail.trim() || status === 'sending'}
+            >
+              {status === 'sending' ? 'Sending…' : 'Send invite'}
+            </button>
+          </div>
+        </form>
+
+        {emailEnabled === false && (
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-4 text-[11px] text-amber-800 leading-relaxed">
+            <div className="font-bold text-xs mb-1">How to enable email on Railway</div>
+            <ol className="list-decimal list-inside space-y-1">
+              <li>In Railway, open the project service for this app and go to <strong>Variables</strong>.</li>
+              <li>Add <code>SMTP_HOST</code> (e.g. your provider hostname{smtpHost ? `, current value: ${smtpHost}` : ''}).</li>
+              <li>Add <code>SMTP_PORT</code> (usually 587), <code>SMTP_USER</code>, <code>SMTP_PASS</code>, and optional <code>SMTP_SECURE=true</code> for TLS.</li>
+              <li>Set <code>FROM_EMAIL</code> if it differs from the SMTP user.</li>
+              <li>Redeploy; the banner will disappear when SMTP is detected.</li>
+            </ol>
+          </div>
+        )}
+
+        {generatedLink && (
+          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mb-4 text-sm text-emerald-700">
+            <div className="font-bold mb-1">Personal invite link</div>
+            <div className="flex items-center justify-between gap-2">
+              <code className="text-xs truncate flex-1">{generatedLink}</code>
+              <button
+                onClick={() => navigator.clipboard.writeText(generatedLink)}
+                className="text-emerald-700 font-bold text-xs hover:underline"
+              >
+                COPY
+              </button>
+            </div>
+          </div>
+        )}
+
         {onLogout && (
             <div className="mb-4 pt-4 border-t border-slate-100 text-center">
                 <p className="text-xs text-slate-400 mb-2">Want to test as another user?</p>
-                <button 
+                <button
                     onClick={onLogout}
                     className="text-indigo-600 text-sm font-bold hover:underline"
                 >

--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -224,7 +224,12 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
               <li>Add <code>SMTP_HOST</code> (e.g. your provider hostname{smtpHost ? `, current value: ${smtpHost}` : ''}).</li>
               <li>Add <code>SMTP_PORT</code> (usually 587), <code>SMTP_USER</code>, <code>SMTP_PASS</code>, and optional <code>SMTP_SECURE=true</code> for TLS.</li>
               <li>Avoid ports 25/465 that are souvent bloqués en sortie sur Railway ; privilégiez le port 587 avec STARTTLS ou 2525 chez certains providers (Mailtrap).</li>
-              <li>Si votre provider est bloqué en egress, déployez le template <a className="underline" href="https://railway.com/deploy/resend-railway-smtp-gateway" target="_blank" rel="noreferrer">Resend Railway SMTP Gateway</a> et copiez les credentials générés vers ces variables.</li>
+              <li>Si votre provider est bloqué en egress, déployez le template <a className="underline" href="https://railway.com/deploy/resend-railway-smtp-gateway" target="_blank" rel="noreferrer">Resend Railway SMTP Gateway</a> :</li>
+              <ul className="list-disc list-inside pl-4 space-y-1">
+                <li>Dans le service gateway, ajoutez <code>RESEND_API_KEY</code> (clé API Resend) pour générer les credentials SMTP.</li>
+                <li>Dans ce projet, mappez vos variables SMTP via des références Railway : <code>SMTP_HOST=${`{{resend-railway-gateway.SMTP_HOST}}`}</code>, <code>SMTP_PORT=${`{{resend-railway-gateway.SMTP_PORT}}`}</code>, <code>SMTP_USER=${`{{resend-railway-gateway.SMTP_USER}}`}</code>, <code>SMTP_PASS=${`{{resend-railway-gateway.SMTP_PASS}}`}</code>.</li>
+                <li>Redéployez : le test SMTP doit réussir et les invitations utiliseront ce relay accessible depuis Railway.</li>
+              </ul>
               <li>Set <code>FROM_EMAIL</code> if it differs from the SMTP user.</li>
               <li>Redeploy; the banner will disappear when SMTP is detected.</li>
             </ol>

--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -58,7 +58,7 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
   const buildTimeoutHint = (code?: string) => {
     if (code && code.includes('ETIMEDOUT')) {
       const hostPort = [smtpHost || 'SMTP host', smtpPort || '587'].join(':');
-      return ` — ${hostPort} inaccessible depuis Railway. Essayez le port 587 avec STARTTLS (SMTP_SECURE=false, SMTP_REQUIRE_TLS=true si nécessaire) ou un provider qui autorise l'egress Railway (ex: Mailtrap, Resend, Brevo).`;
+      return ` — ${hostPort} inaccessible depuis Railway. Essayez le port 587 avec STARTTLS (SMTP_SECURE=false, SMTP_REQUIRE_TLS=true si nécessaire) ou un provider accessible depuis Railway (ex: Mailtrap, Brevo) ou le gateway SMTP Resend sur Railway.`;
     }
     return '';
   };
@@ -224,6 +224,7 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
               <li>Add <code>SMTP_HOST</code> (e.g. your provider hostname{smtpHost ? `, current value: ${smtpHost}` : ''}).</li>
               <li>Add <code>SMTP_PORT</code> (usually 587), <code>SMTP_USER</code>, <code>SMTP_PASS</code>, and optional <code>SMTP_SECURE=true</code> for TLS.</li>
               <li>Avoid ports 25/465 that are souvent bloqués en sortie sur Railway ; privilégiez le port 587 avec STARTTLS ou 2525 chez certains providers (Mailtrap).</li>
+              <li>Si votre provider est bloqué en egress, déployez le template <a className="underline" href="https://railway.com/deploy/resend-railway-smtp-gateway" target="_blank" rel="noreferrer">Resend Railway SMTP Gateway</a> et copiez les credentials générés vers ces variables.</li>
               <li>Set <code>FROM_EMAIL</code> if it differs from the SMTP user.</li>
               <li>Redeploy; the banner will disappear when SMTP is detected.</li>
             </ol>

--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -71,14 +71,20 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
         });
 
         if (!res.ok) {
-          throw new Error('Email service not configured');
+          const body = await res.json().catch(() => ({}));
+          const detail = body?.message || body?.error || 'Email service not configured';
+          const code = body?.code ? ` (${body.code})` : '';
+          throw new Error(`${detail}${code}`);
         }
 
         setStatus('sent');
         setStatusMessage('Invitation sent by email.');
       } catch (err: any) {
         setStatus('error');
-        setStatusMessage(err.message || 'Unable to send email. Copy the link instead.');
+        const codeHint = err?.message?.includes('ETIMEDOUT')
+          ? ' — SMTP host unreachable from Railway. Check host/port/firewall and try port 587 with STARTTLS.'
+          : '';
+        setStatusMessage((err?.message || 'Unable to send email. Copy the link instead.') + codeHint);
       }
     } catch (err: any) {
       setStatus('error');

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -458,6 +458,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // --- Logic ---
   const handleExit = () => {
+      dataService.persistParticipants(team.id, getParticipants());
       if (session.phase !== 'CLOSE') {
           session.status = 'IN_PROGRESS';
       } else {

--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -12,6 +12,10 @@ export interface InviteData {
   members?: User[];
   globalActions?: ActionItem[];
   retrospectives?: RetroSession[];
+  memberId?: string;
+  memberEmail?: string;
+  memberName?: string;
+  inviteToken?: string;
 }
 
 interface Props {
@@ -42,6 +46,12 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
   useEffect(() => {
       setTeams(dataService.getAllTeams());
   }, [view]);
+
+  useEffect(() => {
+    if (inviteData?.memberName) {
+      setName(inviteData.memberName);
+    }
+  }, [inviteData]);
 
   const handleCreate = (e: React.FormEvent) => {
     e.preventDefault();
@@ -76,7 +86,12 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
       return;
     }
     try {
-      const { team, user } = dataService.joinTeamAsParticipant(selectedTeam.id, name.trim());
+      const { team, user } = dataService.joinTeamAsParticipant(
+        selectedTeam.id,
+        name.trim(),
+        inviteData?.memberEmail,
+        inviteData?.inviteToken
+      );
       if (onJoin) {
         onJoin(team, user);
       } else {
@@ -200,11 +215,17 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
                                 required
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
+                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 disabled:bg-slate-100 disabled:text-slate-500"
                                 placeholder="e.g. John Doe"
                                 autoFocus
+                                disabled={!!inviteData?.memberName && !!inviteData?.inviteToken}
                             />
                         </div>
+                        {inviteData?.memberEmail && (
+                          <div className="text-xs text-slate-500 bg-slate-100 border border-slate-200 rounded p-2">
+                            Joining as <strong>{inviteData.memberEmail}</strong>
+                          </div>
+                        )}
                         <button type="submit" className="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold hover:bg-indigo-700 shadow-lg">
                             Join Team
                         </button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "express": "^5.2.1",
+        "nodemailer": "^6.10.0",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "socket.io": "^4.8.1",
@@ -2546,6 +2547,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "express": "^5.2.1",
+    "nodemailer": "^6.10.0",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "socket.io": "^4.8.1",

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ import { Server } from 'socket.io';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import fs from 'fs';
+import nodemailer from 'nodemailer';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -29,6 +30,18 @@ app.use(express.json({ limit: '1mb' }));
 const DATA_FILE = join(__dirname, 'data.json');
 let persistedData = { teams: [] };
 
+const smtpEnabled = !!process.env.SMTP_HOST;
+const mailer = smtpEnabled
+  ? nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: process.env.SMTP_USER
+        ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+        : undefined
+    })
+  : null;
+
 try {
   if (fs.existsSync(DATA_FILE)) {
     persistedData = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
@@ -41,6 +54,10 @@ app.get('/api/data', (_req, res) => {
   res.json(persistedData);
 });
 
+app.get('/api/email-config', (_req, res) => {
+  res.json({ enabled: smtpEnabled, host: process.env.SMTP_HOST || null });
+});
+
 app.post('/api/data', (req, res) => {
   try {
     persistedData = req.body ?? { teams: [] };
@@ -49,6 +66,38 @@ app.post('/api/data', (req, res) => {
   } catch (err) {
     console.error('[Server] Failed to persist data', err);
     res.status(500).json({ error: 'failed_to_persist' });
+  }
+});
+
+app.post('/api/send-invite', async (req, res) => {
+  if (!smtpEnabled || !mailer) {
+    return res.status(501).json({ error: 'email_not_configured' });
+  }
+
+  const { email, name, link, teamName, sessionName } = req.body || {};
+  if (!email || !link) {
+    return res.status(400).json({ error: 'missing_fields' });
+  }
+
+  try {
+    await mailer.sendMail({
+      from: process.env.FROM_EMAIL || process.env.SMTP_USER,
+      to: email,
+      subject: `Invitation to join ${teamName || 'RetroGemini'}`,
+      text: `${name || 'You'},
+
+You have been invited to join ${teamName || 'a RetroGemini team'}${sessionName ? ` for the session "${sessionName}"` : ''}.
+Use this link to join: ${link}
+`,
+      html: `<p>${name || 'You'},</p>
+<p>You have been invited to join <strong>${teamName || 'a RetroGemini team'}</strong>${sessionName ? ` for the session "${sessionName}"` : ''}.</p>
+<p><a href="${link}" target="_blank" rel="noreferrer">Join with this link</a></p>`
+    });
+
+    res.status(204).end();
+  } catch (err) {
+    console.error('[Server] Failed to send invite email', err);
+    res.status(500).json({ error: 'send_failed' });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -27,7 +27,8 @@ app.get('/ready', (_req, res) => res.status(200).send('READY'));
 app.use(express.json({ limit: '1mb' }));
 
 // Basic persistence for teams/actions between browser sessions
-const DATA_FILE = join(__dirname, 'data.json');
+// Allow overriding path to support platforms where /app is read-only (e.g. Railway build output)
+const DATA_FILE = process.env.DATA_FILE_PATH || join(process.env.DATA_DIR || '/tmp', 'data.json');
 let persistedData = { teams: [] };
 
 const smtpEnabled = !!process.env.SMTP_HOST;
@@ -43,6 +44,11 @@ const mailer = smtpEnabled
   : null;
 
 try {
+  const dataDir = dirname(DATA_FILE);
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+
   if (fs.existsSync(DATA_FILE)) {
     persistedData = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
   }

--- a/server.js
+++ b/server.js
@@ -39,7 +39,11 @@ const mailer = smtpEnabled
       secure: process.env.SMTP_SECURE === 'true',
       auth: process.env.SMTP_USER
         ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
-        : undefined
+        : undefined,
+      // Prevent the client from hanging forever on unreachable SMTP hosts
+      connectionTimeout: Number(process.env.SMTP_CONNECTION_TIMEOUT || 15000),
+      greetingTimeout: Number(process.env.SMTP_GREETING_TIMEOUT || 15000),
+      socketTimeout: Number(process.env.SMTP_SOCKET_TIMEOUT || 20000)
     })
   : null;
 
@@ -103,7 +107,9 @@ Use this link to join: ${link}
     res.status(204).end();
   } catch (err) {
     console.error('[Server] Failed to send invite email', err);
-    res.status(500).json({ error: 'send_failed' });
+    const message = err?.message || 'Failed to send email';
+    const code = err?.code || err?.responseCode || null;
+    res.status(500).json({ error: 'send_failed', message, code });
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -31,15 +31,36 @@ app.use(express.json({ limit: '1mb' }));
 const DATA_FILE = process.env.DATA_FILE_PATH || join(process.env.DATA_DIR || '/tmp', 'data.json');
 let persistedData = { teams: [] };
 
-const smtpEnabled = !!process.env.SMTP_HOST;
-const smtpPort = Number(process.env.SMTP_PORT || 587);
+const smtpHost =
+  process.env.SMTP_HOST ||
+  process.env.RESEND_SMTP_HOST ||
+  process.env.RAILWAY_SMTP_HOST ||
+  process.env.RAILWAY_RELAY_SMTP_HOST;
+const smtpUser =
+  process.env.SMTP_USER ||
+  process.env.RESEND_SMTP_USER ||
+  process.env.RAILWAY_SMTP_USER ||
+  process.env.RAILWAY_RELAY_SMTP_USER;
+const smtpPass =
+  process.env.SMTP_PASS ||
+  process.env.RESEND_SMTP_PASS ||
+  process.env.RAILWAY_SMTP_PASS ||
+  process.env.RAILWAY_RELAY_SMTP_PASS;
+const smtpPort = Number(
+  process.env.SMTP_PORT ||
+  process.env.RESEND_SMTP_PORT ||
+  process.env.RAILWAY_SMTP_PORT ||
+  process.env.RAILWAY_RELAY_SMTP_PORT ||
+  587
+);
+const smtpEnabled = !!smtpHost;
 const smtpTimeouts = {
   connectionTimeout: Number(process.env.SMTP_CONNECTION_TIMEOUT || 8000),
   greetingTimeout: Number(process.env.SMTP_GREETING_TIMEOUT || 8000),
   socketTimeout: Number(process.env.SMTP_SOCKET_TIMEOUT || 12000)
 };
 const smtpDebugInfo = {
-  host: process.env.SMTP_HOST || null,
+  host: smtpHost || null,
   port: smtpPort,
   secure: process.env.SMTP_SECURE === 'true' || smtpPort === 465,
   requireTLS: process.env.SMTP_REQUIRE_TLS === 'true',
@@ -48,13 +69,13 @@ const smtpDebugInfo = {
 };
 const mailer = smtpEnabled
   ? nodemailer.createTransport({
-      host: process.env.SMTP_HOST,
+      host: smtpHost,
       port: smtpPort,
       secure: process.env.SMTP_SECURE === 'true' || smtpPort === 465,
       requireTLS: process.env.SMTP_REQUIRE_TLS === 'true',
       ignoreTLS: process.env.SMTP_IGNORE_TLS === 'true',
-      auth: process.env.SMTP_USER
-        ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+      auth: smtpUser
+        ? { user: smtpUser, pass: smtpPass }
         : undefined,
       ...smtpTimeouts
     })

--- a/types.ts
+++ b/types.ts
@@ -6,6 +6,8 @@ export interface User {
   name: string;
   color: string;
   role: Role;
+  email?: string;
+  inviteToken?: string;
 }
 
 export interface Column {


### PR DESCRIPTION
## Summary
- add server endpoint to expose SMTP configuration state for the UI
- surface Railway SMTP setup guidance in the invite modal when email is disabled
- document required SMTP variables in the Railway deployment guide

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403e59cf288327b3322f33db80b53a)