### PR TITLE
Enhance invitations and session persistence

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -61,7 +61,9 @@ const App: React.FC = () => {
 
   useEffect(() => {
     if (!currentTeam || !currentUser) {
-      localStorage.removeItem(STORAGE_KEY);
+      if (hydrated) {
+        localStorage.removeItem(STORAGE_KEY);
+      }
       return;
     }
 
@@ -75,7 +77,7 @@ const App: React.FC = () => {
     };
 
     localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
-  }, [currentTeam, currentUser, view, activeSessionId]);
+  }, [currentTeam, currentUser, view, activeSessionId, hydrated]);
 
   // Check for invitation link on mount
   useEffect(() => {

--- a/App.tsx
+++ b/App.tsx
@@ -14,9 +14,68 @@ const App: React.FC = () => {
   const [pendingSessionId, setPendingSessionId] = useState<string | null>(null);
   const [hydrated, setHydrated] = useState(false);
 
+  const STORAGE_KEY = 'retro-open-session';
+
   useEffect(() => {
     dataService.hydrateFromServer().finally(() => setHydrated(true));
   }, []);
+
+  useEffect(() => {
+    if (!hydrated || currentTeam) return;
+
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const saved = JSON.parse(raw);
+      const team = dataService.getTeam(saved.teamId);
+      if (!team) return;
+
+      let user = team.members.find(m => m.id === saved.userId) || team.members.find(m => m.email && m.email === saved.userEmail);
+      if (!user && saved.userName) {
+        const participants = team.retrospectives.flatMap(r => r.participants || []);
+        const found = participants.find(p => p.id === saved.userId || p.name === saved.userName);
+        if (found) {
+          dataService.persistParticipants(team.id, [found]);
+          user = found;
+        }
+      }
+
+      if (!user) return;
+
+      setCurrentTeam(team);
+      setCurrentUser(user);
+      if (saved.view === 'SESSION' && saved.activeSessionId) {
+        const sessionExists = team.retrospectives.some(r => r.id === saved.activeSessionId);
+        if (sessionExists) {
+          setActiveSessionId(saved.activeSessionId);
+          setView('SESSION');
+          return;
+        }
+      }
+
+      setView(saved.view || 'DASHBOARD');
+    } catch (err) {
+      console.warn('Unable to restore previous session', err);
+    }
+  }, [hydrated, currentTeam]);
+
+  useEffect(() => {
+    if (!currentTeam || !currentUser) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+
+    const payload = {
+      teamId: currentTeam.id,
+      userId: currentUser.id,
+      userEmail: currentUser.email,
+      userName: currentUser.name,
+      view,
+      activeSessionId,
+    };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }, [currentTeam, currentUser, view, activeSessionId]);
 
   // Check for invitation link on mount
   useEffect(() => {
@@ -97,6 +156,7 @@ const App: React.FC = () => {
     setCurrentTeam(null);
     setCurrentUser(null);
     setView('LOGIN');
+    localStorage.removeItem(STORAGE_KEY);
   };
 
   const handleOpenSession = (sessionId: string) => {

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefresh, onDeleteTeam }) => {
-  const [tab, setTab] = useState<'ACTIONS' | 'RETROS'>('ACTIONS');
+  const [tab, setTab] = useState<'ACTIONS' | 'RETROS' | 'MEMBERS'>('ACTIONS');
   const [actionFilter, setActionFilter] = useState<'OPEN' | 'CLOSED' | 'ALL'>('OPEN');
   const [showNewRetroModal, setShowNewRetroModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -372,6 +372,9 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
         <button onClick={() => setTab('RETROS')} className={`dash-tab px-6 py-3 font-bold text-sm flex items-center transition ${tab === 'RETROS' ? 'active' : 'text-slate-500 hover:text-retro-primary'}`}>
             <span className="material-symbols-outlined mr-2">history</span> Retrospectives
         </button>
+        <button onClick={() => setTab('MEMBERS')} className={`dash-tab px-6 py-3 font-bold text-sm flex items-center transition ${tab === 'MEMBERS' ? 'active' : 'text-slate-500 hover:text-retro-primary'}`}>
+            <span className="material-symbols-outlined mr-2">groups</span> Members
+        </button>
       </div>
 
       {tab === 'ACTIONS' && (
@@ -492,9 +495,29 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
                             </button>
                         </div>
                     </div>
-                  ))
-              )}
+                ))
+            )}
           </div>
+      )}
+
+      {tab === 'MEMBERS' && (
+        <div className="max-w-3xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-3">
+          {team.members.map((member) => (
+            <div key={member.id} className="bg-white border border-slate-200 rounded-xl p-4 shadow-sm flex items-center gap-3">
+              <div className={`w-10 h-10 rounded-full ${member.color} text-white flex items-center justify-center font-bold uppercase`}>
+                {member.name.substring(0, 2)}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-bold text-slate-800">{member.name}</span>
+                <span className="text-[11px] uppercase tracking-wide text-slate-400">{member.role}</span>
+                {member.email && <span className="text-xs text-slate-500">{member.email}</span>}
+              </div>
+            </div>
+          ))}
+          {team.members.length === 0 && (
+            <div className="text-center text-slate-400 py-10 col-span-full">No members yet.</div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/components/InviteModal.tsx
+++ b/components/InviteModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Team, RetroSession } from '../types';
 import { dataService } from '../services/dataService';
 
@@ -9,15 +9,15 @@ interface Props {
   onLogout?: () => void;
 }
 
-const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }) => {
-  const [inviteeName, setInviteeName] = useState('');
-  const [inviteeEmail, setInviteeEmail] = useState('');
-  const [generatedLink, setGeneratedLink] = useState('');
-  const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'error'>('idle');
-  const [statusMessage, setStatusMessage] = useState('');
+type StatusState = 'idle' | 'sending' | 'sent' | 'error';
 
-  // Encode essential team data for invitation (id, name, password)
-  // Also include active session data if available
+const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }) => {
+  const [activeTab, setActiveTab] = useState<'email' | 'link'>('email');
+  const [emailsInput, setEmailsInput] = useState('');
+  const [status, setStatus] = useState<StatusState>('idle');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [generatedLinks, setGeneratedLinks] = useState<{ email: string; link: string }[]>([]);
+
   const inviteData: {
     id: string;
     name: string;
@@ -34,140 +34,197 @@ const InviteModal: React.FC<Props> = ({ team, activeSession, onClose, onLogout }
   const link = `${window.location.origin}?join=${encodedData}`;
   const qrUrl = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(link)}`;
 
-  const handlePersonalInvite = async (e: React.FormEvent) => {
+  const emailList = useMemo(() => {
+    return emailsInput
+      .split(/\n|,|;/)
+      .map(e => e.trim())
+      .filter(Boolean);
+  }, [emailsInput]);
+
+  const handleEmailInvite = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inviteeEmail.trim()) return;
+    if (emailList.length === 0) return;
 
-    try {
-      setStatus('sending');
-      setStatusMessage('Sending email invite…');
-      const { inviteLink } = dataService.createMemberInvite(team.id, inviteeName.trim(), inviteeEmail.trim(), activeSession?.id);
-      setGeneratedLink(inviteLink);
+    setStatus('sending');
+    setStatusMessage('Sending invites…');
 
+    const successes: { email: string; link: string }[] = [];
+    const errors: string[] = [];
+
+    for (const email of emailList) {
       try {
-        const res = await fetch('/api/send-invite', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            email: inviteeEmail.trim(),
-            name: inviteeName.trim() || inviteeEmail.trim(),
-            link: inviteLink,
-            teamName: team.name,
-            sessionName: activeSession?.name,
-          })
-        });
+        const { inviteLink } = dataService.createMemberInvite(team.id, email, activeSession?.id);
+        successes.push({ email, link: inviteLink });
 
-        if (!res.ok) {
-          throw new Error('Email service not configured');
+        try {
+          const res = await fetch('/api/send-invite', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              email,
+              name: email,
+              link: inviteLink,
+              teamName: team.name,
+              sessionName: activeSession?.name,
+            })
+          });
+
+          if (!res.ok) {
+            throw new Error('Email service not configured');
+          }
+        } catch (err: any) {
+          errors.push(`${email}: ${err.message || 'Failed to send email'}`);
         }
-
-        setStatus('sent');
-        setStatusMessage('Invitation sent by email.');
       } catch (err: any) {
-        setStatus('error');
-        setStatusMessage(err.message || 'Unable to send email. Copy the link instead.');
+        errors.push(`${email}: ${err.message || 'Unable to generate invite'}`);
       }
-    } catch (err: any) {
+    }
+
+    if (successes.length) {
+      setGeneratedLinks(successes);
+      setStatus('sent');
+      setStatusMessage(`${successes.length} invite${successes.length > 1 ? 's' : ''} ready to share`);
+      setEmailsInput('');
+    } else {
+      setGeneratedLinks([]);
       setStatus('error');
-      setStatusMessage(err.message || 'Failed to generate invite');
+      setStatusMessage('No invites created');
+    }
+
+    if (errors.length) {
+      setStatus('error');
+      setStatusMessage(errors.join(' | '));
     }
   };
 
+  const renderEmailTab = () => (
+    <form onSubmit={handleEmailInvite} className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-bold text-slate-700">Invite by email</p>
+          <p className="text-xs text-slate-500">Paste one or more email addresses to send personal links.</p>
+        </div>
+        {status !== 'idle' && (
+          <span className={`text-xs font-bold ${status === 'sent' ? 'text-emerald-600' : status === 'sending' ? 'text-slate-500' : 'text-amber-600'}`}>
+            {statusMessage}
+          </span>
+        )}
+      </div>
+
+      <textarea
+        className="w-full border border-slate-200 rounded-lg p-3 text-sm bg-white text-slate-900 h-28"
+        placeholder="e.g. teammate@example.com, other@company.com"
+        value={emailsInput}
+        onChange={(e) => setEmailsInput(e.target.value)}
+      />
+
+      {emailList.length > 0 && (
+        <div className="flex flex-wrap gap-2 text-xs text-slate-600">
+          {emailList.map(email => (
+            <span key={email} className="px-2 py-1 bg-slate-100 border border-slate-200 rounded-full">{email}</span>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        className="w-full px-4 py-2 bg-indigo-600 text-white rounded-lg font-bold text-sm hover:bg-indigo-700 disabled:opacity-50"
+        disabled={!emailList.length || status === 'sending'}
+      >
+        {status === 'sending' ? 'Sending…' : 'Send invites'}
+      </button>
+
+      {generatedLinks.length > 0 && (
+        <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 text-sm text-emerald-700 space-y-2">
+          <div className="font-bold">Invite links ready</div>
+          <div className="space-y-1 max-h-32 overflow-auto pr-1">
+            {generatedLinks.map(({ email, link }) => (
+              <div key={email} className="flex items-center gap-2">
+                <span className="text-xs font-semibold text-emerald-800 min-w-[120px] truncate">{email}</span>
+                <code className="text-[11px] truncate flex-1">{link}</code>
+                <button
+                  type="button"
+                  onClick={() => navigator.clipboard.writeText(link)}
+                  className="text-emerald-700 font-bold text-[10px] hover:underline"
+                >
+                  COPY
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </form>
+  );
+
+  const renderLinkTab = () => (
+    <div className="space-y-4">
+      <div className="text-center">
+        <p className="text-sm font-bold text-slate-700">Share via link or QR code</p>
+        <p className="text-xs text-slate-500">Anyone can join and choose their name after scanning.</p>
+      </div>
+
+      <div className="flex justify-center">
+        <div className="p-4 bg-white border border-slate-200 rounded-xl shadow-inner">
+          <img src={qrUrl} alt="QR Code" className="w-48 h-48" />
+        </div>
+      </div>
+
+      <div className="bg-slate-50 p-3 rounded-lg border border-slate-200 flex items-center justify-between">
+        <code className="text-xs text-slate-600 truncate mr-2">{link}</code>
+        <button
+          onClick={() => navigator.clipboard.writeText(link)}
+          className="text-retro-primary font-bold text-xs hover:underline"
+        >
+          COPY
+        </button>
+      </div>
+    </div>
+  );
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[100] backdrop-blur-sm">
-      <div className="bg-white rounded-2xl shadow-2xl p-8 max-w-sm w-full relative">
-        <button 
-            onClick={onClose}
-            className="absolute top-4 right-4 text-slate-400 hover:text-slate-600"
+      <div className="bg-white rounded-2xl shadow-2xl p-6 max-w-xl w-full relative">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-400 hover:text-slate-600"
         >
-            <span className="material-symbols-outlined">close</span>
+          <span className="material-symbols-outlined">close</span>
         </button>
 
-        <h3 className="text-xl font-bold text-slate-800 mb-2 text-center">Join {team.name}</h3>
-        <p className="text-slate-500 text-sm text-center mb-6">Scan to join this team instantly.</p>
+        <h3 className="text-xl font-bold text-slate-800 mb-1 text-center">Invite teammates to {team.name}</h3>
+        <p className="text-slate-500 text-sm text-center mb-4">Choose how you want to invite participants.</p>
 
-        <div className="flex justify-center mb-6">
-            <div className="p-4 bg-white border border-slate-200 rounded-xl shadow-inner">
-                <img src={qrUrl} alt="QR Code" className="w-48 h-48" />
-            </div>
+        <div className="flex border-b border-slate-200 mb-6">
+          <button
+            className={`flex-1 py-2 text-sm font-bold ${activeTab === 'email' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-400'}`}
+            onClick={() => setActiveTab('email')}
+          >
+            EMAIL
+          </button>
+          <button
+            className={`flex-1 py-2 text-sm font-bold ${activeTab === 'link' ? 'text-indigo-600 border-b-2 border-indigo-600' : 'text-slate-400'}`}
+            onClick={() => setActiveTab('link')}
+          >
+            CODE & LINK
+          </button>
         </div>
 
-        <div className="bg-slate-50 p-3 rounded-lg border border-slate-200 flex items-center justify-between mb-4">
-            <code className="text-xs text-slate-600 truncate mr-2">{link}</code>
-            <button
-                onClick={() => navigator.clipboard.writeText(link)}
-                className="text-retro-primary font-bold text-xs hover:underline"
-            >
-                COPY
-            </button>
-        </div>
-
-        <form onSubmit={handlePersonalInvite} className="mb-4 space-y-3 border-t border-slate-100 pt-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-bold text-slate-700">Invite by email</p>
-              <p className="text-xs text-slate-500">Send a unique link tied to an email.</p>
-            </div>
-            {status !== 'idle' && (
-              <span className={`text-xs font-bold ${status === 'sent' ? 'text-emerald-600' : status === 'sending' ? 'text-slate-500' : 'text-amber-600'}`}>
-                {statusMessage}
-              </span>
-            )}
-          </div>
-          <input
-            type="text"
-            placeholder="Name (optional)"
-            value={inviteeName}
-            onChange={(e) => setInviteeName(e.target.value)}
-            className="w-full border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
-          />
-          <div className="flex gap-2">
-            <input
-              type="email"
-              placeholder="email@example.com"
-              required
-              value={inviteeEmail}
-              onChange={(e) => setInviteeEmail(e.target.value)}
-              className="flex-1 border border-slate-200 rounded-lg p-2 text-sm bg-white text-slate-900"
-            />
-            <button
-              type="submit"
-              className="px-4 py-2 bg-indigo-600 text-white rounded-lg font-bold text-sm hover:bg-indigo-700 disabled:opacity-50"
-              disabled={!inviteeEmail.trim() || status === 'sending'}
-            >
-              {status === 'sending' ? 'Sending…' : 'Send invite'}
-            </button>
-          </div>
-        </form>
-
-        {generatedLink && (
-          <div className="bg-emerald-50 border border-emerald-200 rounded-lg p-3 mb-4 text-sm text-emerald-700">
-            <div className="font-bold mb-1">Personal invite link</div>
-            <div className="flex items-center justify-between gap-2">
-              <code className="text-xs truncate flex-1">{generatedLink}</code>
-              <button
-                onClick={() => navigator.clipboard.writeText(generatedLink)}
-                className="text-emerald-700 font-bold text-xs hover:underline"
-              >
-                COPY
-              </button>
-            </div>
-          </div>
-        )}
+        {activeTab === 'email' ? renderEmailTab() : renderLinkTab()}
 
         {onLogout && (
-            <div className="mb-4 pt-4 border-t border-slate-100 text-center">
-                <p className="text-xs text-slate-400 mb-2">Want to test as another user?</p>
-                <button
-                    onClick={onLogout}
-                    className="text-indigo-600 text-sm font-bold hover:underline"
-                >
-                    Logout & Create New User
-                </button>
-            </div>
+          <div className="mt-6 pt-4 border-t border-slate-100 text-center">
+            <p className="text-xs text-slate-400 mb-2">Want to test as another user?</p>
+            <button
+              onClick={onLogout}
+              className="text-indigo-600 text-sm font-bold hover:underline"
+            >
+              Logout & Create New User
+            </button>
+          </div>
         )}
 
-        <button onClick={onClose} className="w-full bg-slate-800 text-white py-2 rounded-lg font-bold">Done</button>
+        <button onClick={onClose} className="w-full bg-slate-800 text-white py-2 rounded-lg font-bold mt-4">Done</button>
       </div>
     </div>
   );

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -95,15 +95,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
   const getParticipants = () => {
-    let roster: User[] = [];
-
-    if (sessionRef.current?.participants && sessionRef.current.participants.length > 0) {
-      roster = [...sessionRef.current.participants];
-    } else if (session?.participants && session.participants.length > 0) {
-      roster = [...session.participants];
-    } else {
-      roster = [...team.members];
-    }
+    const roster = sessionRef.current?.participants?.length
+      ? [...sessionRef.current.participants]
+      : session?.participants?.length
+      ? [...session.participants]
+      : [];
 
     if (!roster.some(p => p.id === currentUser.id)) {
       roster.push(currentUser);

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -299,6 +299,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
     updater(newSession);
     dataService.updateSession(team.id, newSession);
+    dataService.persistParticipants(team.id, newSession.participants);
     setSession(newSession);
     // Sync to other clients via WebSocket
     syncService.updateSession(newSession);

--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -214,10 +214,9 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
                                 required
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
-                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 disabled:bg-slate-100 disabled:text-slate-500"
+                                className="w-full border border-slate-300 rounded-lg p-3 bg-white text-slate-900 outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500"
                                 placeholder="e.g. John Doe"
                                 autoFocus
-                                disabled={!!inviteData?.memberName && !!inviteData?.inviteToken}
                             />
                         </div>
                         {inviteData?.memberEmail && (

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -333,7 +333,7 @@ export const dataService = {
   getPresets: () => PRESETS,
   getHex,
 
-  createMemberInvite: (teamId: string, name: string, email: string, sessionId?: string) => {
+  createMemberInvite: (teamId: string, email: string, sessionId?: string, nameHint?: string) => {
     const data = loadData();
     const team = data.teams.find(t => t.id === teamId);
     if (!team) throw new Error('Team not found');
@@ -343,12 +343,12 @@ export const dataService = {
 
     let user = team.members.find(m => normalizeEmail(m.email) === normalizedEmail);
     if (user) {
-      user.name = name || user.name;
+      user.name = nameHint || user.name || normalizedEmail.split('@')[0];
       if (!user.inviteToken) user.inviteToken = Math.random().toString(36).slice(2, 10);
     } else {
       user = {
         id: Math.random().toString(36).substr(2, 9),
-        name: name || email,
+        name: nameHint || email.split('@')[0],
         color: USER_COLORS[team.members.length % USER_COLORS.length],
         role: 'participant',
         email: normalizedEmail,
@@ -366,7 +366,6 @@ export const dataService = {
       sessionId,
       memberId: user.id,
       memberEmail: user.email,
-      memberName: user.name,
       inviteToken: user.inviteToken
     };
 

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -176,7 +176,7 @@ export const dataService = {
       date: new Date().toLocaleDateString(),
       status: 'IN_PROGRESS',
       phase: 'ICEBREAKER', // Skipped SETUP
-      participants: [...team.members],
+      participants: [],
       discussionFocusId: null,
       icebreakerQuestion: icebreakerQuestion,
       columns: templateCols,


### PR DESCRIPTION
## Summary
- overhaul invite modal with email and link tabs, multi-email support, and clearer QR/link sharing
- allow invitees to choose their own names while persisting participants and roster updates to the team
- restore the last open session on refresh so participants stay in their retrospective

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941781e37e483279ac9f68def035c42)