### PR TITLE
Add session-specific URLs and keep invitee names

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -105,6 +105,26 @@ const App: React.FC = () => {
     }
   }, [view, activeSessionId, hydrated]);
 
+  // Participants should never remain on the dashboard; force them into a session or log them out.
+  useEffect(() => {
+    if (!hydrated || !currentTeam || !currentUser) return;
+    if (currentUser.role !== 'participant') return;
+    if (view !== 'DASHBOARD') return;
+
+    const targetSession =
+      (activeSessionId && currentTeam.retrospectives.find(r => r.id === activeSessionId)) ||
+      currentTeam.retrospectives.find(r => r.status === 'IN_PROGRESS') ||
+      currentTeam.retrospectives[0];
+
+    if (targetSession) {
+      setActiveSessionId(targetSession.id);
+      setView('SESSION');
+      return;
+    }
+
+    handleLogout();
+  }, [hydrated, currentTeam, currentUser, view, activeSessionId]);
+
   // Check for invitation link on mount
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);

--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,10 @@ const App: React.FC = () => {
   useEffect(() => {
     if (!hydrated || currentTeam) return;
 
+    // If the URL contains an invite payload, skip restoring local session state.
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('join')) return;
+
     try {
       const pathMatch = window.location.pathname.match(SESSION_PATH_REGEX);
       const sessionFromPath = pathMatch?.[1] || null;

--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -68,9 +68,18 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
         (normalizedEmail && normalizeEmail(member.email) === normalizedEmail)
     );
 
+    const previouslyJoined = existingMember
+      ? existingMember.joinedBefore ||
+        selectedTeam.retrospectives.some((retro) =>
+          (retro.participants || []).some(
+            (p) => p.id === existingMember.id || p.name.toLowerCase() === existingMember.name.toLowerCase()
+          )
+        )
+      : false;
+
     if (existingMember) {
       setName(existingMember.name);
-      setNameLocked(true);
+      setNameLocked(!!previouslyJoined);
     } else if (inviteData.memberName) {
       setName(inviteData.memberName);
       setNameLocked(false);

--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -266,7 +266,7 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData }) => {
                           </div>
                         )}
                         <button type="submit" className="w-full bg-indigo-600 text-white py-3 rounded-lg font-bold hover:bg-indigo-700 shadow-lg">
-                            Join Team
+                            Join Retrospective
                         </button>
                     </form>
                     <p className="text-xs text-slate-400 text-center mt-4">

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -512,7 +512,12 @@ export const dataService = {
       if (normalizedEmail && existingUser.email !== normalizedEmail) existingUser.email = normalizedEmail;
       if (inviteToken && !existingUser.inviteToken) existingUser.inviteToken = inviteToken;
 
-      if ((!matchedByIdentity && existingUser.name !== userName) || !existingUser.name) {
+      const shouldUpdateName =
+        !existingUser.joinedBefore ||
+        (!matchedByIdentity && existingUser.name !== userName) ||
+        !existingUser.name;
+
+      if (shouldUpdateName) {
         existingUser.name = userName;
       }
 

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -516,6 +516,8 @@ export const dataService = {
         existingUser.name = userName;
       }
 
+      existingUser.joinedBefore = true;
+
       saveData(data);
       return { team, user: existingUser };
     }
@@ -527,7 +529,8 @@ export const dataService = {
       color: USER_COLORS[team.members.length % USER_COLORS.length],
       role: 'participant',
       email: normalizedEmail || undefined,
-      inviteToken: inviteToken || Math.random().toString(36).slice(2, 10)
+      inviteToken: inviteToken || Math.random().toString(36).slice(2, 10),
+      joinedBefore: true
     };
     team.members.push(newUser);
     saveData(data);

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -506,9 +506,16 @@ export const dataService = {
       return m.name.toLowerCase() === userName.toLowerCase();
     });
     if (existingUser) {
-      existingUser.name = userName;
-      if (normalizedEmail) existingUser.email = normalizedEmail;
+      const matchedByIdentity = (inviteToken && existingUser.inviteToken === inviteToken) ||
+        (normalizedEmail && normalizeEmail(existingUser.email) === normalizedEmail);
+
+      if (normalizedEmail && existingUser.email !== normalizedEmail) existingUser.email = normalizedEmail;
       if (inviteToken && !existingUser.inviteToken) existingUser.inviteToken = inviteToken;
+
+      if ((!matchedByIdentity && existingUser.name !== userName) || !existingUser.name) {
+        existingUser.name = userName;
+      }
+
       saveData(data);
       return { team, user: existingUser };
     }

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface User {
   role: Role;
   email?: string;
   inviteToken?: string;
+  joinedBefore?: boolean;
 }
 
 export interface Column {


### PR DESCRIPTION
## Summary
- add session-specific URLs and default the base path back to the dashboard when reopening the app
- prefilling and locking invitee names when an existing participant follows their link
- keep stored participant names when rejoining via email/token invitations while still updating contact details

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943350604d08327a0c22b2969f414e2)