### PR TITLE
Add ability to remove team members while preserving assignments

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -265,7 +265,10 @@ const App: React.FC = () => {
                     onOpenSession={handleOpenSession}
                     onRefresh={() => {
                         const updated = dataService.getTeam(currentTeam.id);
-                        if(updated) setCurrentTeam(updated);
+                        if(updated) {
+                            // Clone to force render when dataService mutates in-place
+                            setCurrentTeam(JSON.parse(JSON.stringify(updated)));
+                        }
                     }}
                     onDeleteTeam={handleLogout}
                 />
@@ -279,7 +282,9 @@ const App: React.FC = () => {
                 onExit={() => {
                     // Refresh data before exiting
                     const updated = dataService.getTeam(currentTeam.id);
-                    if(updated) setCurrentTeam(updated);
+                    if(updated) {
+                        setCurrentTeam(JSON.parse(JSON.stringify(updated)));
+                    }
 
                     if (currentUser?.role === 'participant') {
                       handleLogout();

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -18,6 +18,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [retroToDelete, setRetroToDelete] = useState<RetroSession | null>(null);
+  const [memberPendingRemoval, setMemberPendingRemoval] = useState<string | null>(null);
 
   // Action Creation State
   const [newActionText, setNewActionText] = useState('');
@@ -105,6 +106,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
   const handleRemoveMember = (memberId: string) => {
     if (memberId === currentUser.id) return;
     dataService.removeMember(team.id, memberId);
+    setMemberPendingRemoval(null);
     onRefresh();
   };
 
@@ -543,17 +545,33 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
                 {member.email && <span className="text-xs text-slate-500">{member.email}</span>}
               </div>
               {isAdmin && member.id !== currentUser.id && (
-                <button
-                  onClick={() => {
-                    if (confirm(`Remove ${member.name} from the team?`)) {
-                      handleRemoveMember(member.id);
-                    }
-                  }}
-                  className="ml-auto text-slate-300 hover:text-red-500"
-                  title="Remove member"
-                >
-                  <span className="material-symbols-outlined">person_remove</span>
-                </button>
+                <div className="ml-auto flex items-center gap-2">
+                  {memberPendingRemoval === member.id ? (
+                    <div className="flex items-center gap-2 bg-red-50 border border-red-100 rounded-full px-3 py-1 text-xs font-semibold text-red-700">
+                      <span>Remove?</span>
+                      <button
+                        onClick={() => handleRemoveMember(member.id)}
+                        className="bg-red-600 text-white px-2 py-0.5 rounded-full hover:bg-red-700"
+                      >
+                        Confirm
+                      </button>
+                      <button
+                        onClick={() => setMemberPendingRemoval(null)}
+                        className="text-red-600 hover:text-red-700"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  ) : (
+                    <button
+                      onClick={() => setMemberPendingRemoval(member.id)}
+                      className="text-slate-300 hover:text-red-500"
+                      title="Remove member"
+                    >
+                      <span className="material-symbols-outlined">person_remove</span>
+                    </button>
+                  )}
+                </div>
               )}
             </div>
           ))}

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -33,6 +33,9 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
   const [retroName, setRetroName] = useState('');
   const [isAnonymous, setIsAnonymous] = useState(false);
 
+  const archivedMembers = team.archivedMembers || [];
+  const knownMembers = [...team.members, ...archivedMembers];
+
   // Combine global actions and actions from all retros
   const allActions = [
       ...team.globalActions.map(a => ({...a, originRetro: 'Dashboard', contextText: ''})),
@@ -97,6 +100,12 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
           dataService.updateGlobalAction(team.id, updated);
           onRefresh();
       }
+  };
+
+  const handleRemoveMember = (memberId: string) => {
+    if (memberId === currentUser.id) return;
+    dataService.removeMember(team.id, memberId);
+    onRefresh();
   };
 
   const handleUpdateActionText = (actionId: string, newText: string) => {
@@ -438,7 +447,27 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
                                 </div>
                             </div>
                             <div className="flex items-center">
-                                <select 
+                                {action.assigneeId && !team.members.some(m => m.id === action.assigneeId) && (
+                                    (() => {
+                                        const archived = knownMembers.find(m => m.id === action.assigneeId);
+                                        if (!archived) return null;
+                                        return (
+                                          <select
+                                            value={action.assigneeId || ''}
+                                            onChange={(e) => handleUpdateAssignee(action.id, e.target.value || null)}
+                                            className="text-xs border border-slate-200 rounded p-1.5 bg-amber-50 text-amber-700 focus:border-retro-primary focus:ring-1 focus:ring-indigo-100 outline-none"
+                                          >
+                                            <option value={archived.id}>{archived.name} (removed)</option>
+                                            {team.members.map(m => (
+                                                <option key={m.id} value={m.id}>{m.name}</option>
+                                            ))}
+                                            <option value="">Unassigned</option>
+                                          </select>
+                                        );
+                                    })()
+                                )}
+                                {!action.assigneeId || team.members.some(m => m.id === action.assigneeId) ? (
+                                <select
                                     value={action.assigneeId || ''}
                                     onChange={(e) => handleUpdateAssignee(action.id, e.target.value || null)}
                                     className="text-xs border border-slate-200 rounded p-1.5 bg-white text-slate-600 focus:border-retro-primary focus:ring-1 focus:ring-indigo-100 outline-none"
@@ -448,6 +477,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
                                         <option key={m.id} value={m.id}>{m.name}</option>
                                     ))}
                                 </select>
+                                ) : null}
                             </div>
                         </div>
                     ))
@@ -512,6 +542,19 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onRefres
                 <span className="text-[11px] uppercase tracking-wide text-slate-400">{member.role}</span>
                 {member.email && <span className="text-xs text-slate-500">{member.email}</span>}
               </div>
+              {isAdmin && member.id !== currentUser.id && (
+                <button
+                  onClick={() => {
+                    if (confirm(`Remove ${member.name} from the team?`)) {
+                      handleRemoveMember(member.id);
+                    }
+                  }}
+                  className="ml-auto text-slate-300 hover:text-red-500"
+                  title="Remove member"
+                >
+                  <span className="material-symbols-outlined">person_remove</span>
+                </button>
+              )}
             </div>
           ))}
           {team.members.length === 0 && (

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -1158,6 +1158,13 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
                             >
                                 <option value="">Unassigned</option>
                                {participants.map(m => <option key={m.id} value={m.id}>{m.name}</option>)}
+                               {action.assigneeId && !participants.some(p => p.id === action.assigneeId) && (
+                                 (() => {
+                                    const archived = (team.archivedMembers || []).find(m => m.id === action.assigneeId);
+                                    if (!archived) return null;
+                                    return <option key={archived.id} value={archived.id}>{archived.name} (removed)</option>;
+                                 })()
+                               )}
                             </select>
                         </div>
                     )})}
@@ -1704,6 +1711,13 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
                     {participants.map(m => (
                         <option key={m.id} value={m.id}>{m.name}</option>
                     ))}
+                    {action.assigneeId && !participants.some(p => p.id === action.assigneeId) && (
+                        (() => {
+                            const archived = (team.archivedMembers || []).find(m => m.id === action.assigneeId);
+                            if (!archived) return null;
+                            return <option key={archived.id} value={archived.id}>{archived.name} (removed)</option>;
+                        })()
+                    )}
                 </select>
                 {isFacilitator && !isGlobal && (
                     <div className="ml-3">

--- a/types.ts
+++ b/types.ts
@@ -90,6 +90,7 @@ export interface Team {
   name: string;
   passwordHash: string;
   members: User[];
+  archivedMembers?: User[];
   customTemplates: { name: string; cols: Column[] }[];
   retrospectives: RetroSession[];
   globalActions: ActionItem[];


### PR DESCRIPTION
## Summary
- add archived member tracking and removal capability without disturbing existing assignments
- prevent auto-readding removed members from persisted participant lists
- surface member removal controls in dashboard and keep removed assignees visible in selectors

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694594742b8c83279d58586d006bfba7)