### PR TITLE
Enable touch ticket grouping on mobile

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -604,6 +604,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
   };
 
   const handleTouchStart = (ticket: Ticket) => {
+      // Avoid replacing the currently selected card when we're already in a touch-drag flow
+      if (isTouchDragging && draggedTicket) {
+          return;
+      }
+
       setDraggedTicket(ticket);
       setIsTouchDragging(true);
       setDragTarget({ type: 'ITEM', id: ticket.id });


### PR DESCRIPTION
## Summary
- add touch-driven selection workflow so cards can be grouped on mobile
- provide instructional banner and column drop button for touch devices
- keep drag-and-drop behavior intact for desktop while reusing drop logic

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a8e86d40832795eb5b300f0fdbb6)