### PR TITLE
Handle super admin rate limiting gracefully

### DIFF
--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -220,6 +220,11 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData, onSuperAdminL
         if (response.status === 503) {
           throw new Error('Super admin not configured on this server');
         }
+        if (response.status === 429) {
+          const data = await response.json().catch(() => null);
+          const retryAfter = data?.retryAfter ? ` Try again in ${data.retryAfter}.` : ' Try again later.';
+          throw new Error(`Too many attempts.${retryAfter}`);
+        }
         throw new Error('Invalid super admin password');
       }
 


### PR DESCRIPTION
### Motivation
- Fix misleading "Failed to load teams" and "Invalid super admin password" errors that occur when the super-admin verification endpoint is throttled or the session expires.
- Prevent admin actions (listing teams, updating facilitator emails) from being blocked by the stricter brute-force limiter used for password verification.
- Surface clear UI messages for throttling (`429`) and expired/unauthorized sessions (`401`) so the user knows to retry or re-authenticate.
- Make the skip logic for super-admin rate limiting reusable to avoid duplication.

### Description
- Extracted `shouldSkipSuperAdminLimit` and added a new `superAdminActionLimiter` with a higher `max` to allow more frequent admin actions while keeping `authLimiter` strict for verification.
- Switched `/api/super-admin/teams` and `/api/super-admin/update-email` to use `superAdminActionLimiter` and kept `/api/super-admin/verify` behind `authLimiter`.
- Added `getRateLimitMessage` in `components/SuperAdmin.tsx` and updated `loadTeams` and `handleUpdateEmail` to handle `401` and `429` responses with friendly messages such as `Super admin session expired. Please log in again.` and `Too many attempts` including `retryAfter` when present.
- Updated `components/TeamLogin.tsx` `handleSuperAdminLogin` to surface `429` retry messages instead of showing a generic invalid-password error.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1fba582083278498e4e6d5647bb5)