### PR TITLE
Translate picker comments to English

### DIFF
--- a/components/ColorPicker.tsx
+++ b/components/ColorPicker.tsx
@@ -33,7 +33,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ initialColor = '#6366F
   const handleColorSelect = (color: string) => {
     setSelectedColor(color);
     onChange(color);
-    // Auto-close après sélection
+    // Auto-close after selection
     if (onClose) {
       setTimeout(() => onClose(), 150);
     }

--- a/components/IconPicker.tsx
+++ b/components/IconPicker.tsx
@@ -192,7 +192,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({ initialIcon = 'star', on
   const handleIconSelect = (iconName: string) => {
     setSelectedIcon(iconName);
     onChange(iconName);
-    // Auto-close après sélection
+    // Auto-close after selection
     if (onClose) {
       setTimeout(() => onClose(), 150);
     }


### PR DESCRIPTION
### Motivation
- Replace non-English inline comments to maintain a consistent codebase language.
- Improve clarity for contributors who read English comments.

### Description
- Replaced the French comment `// Auto-close après sélection` with `// Auto-close after selection` in `components/ColorPicker.tsx`.
- Replaced the French comment `// Auto-close après sélection` with `// Auto-close after selection` in `components/IconPicker.tsx`.

### Testing
- This is a comment-only change and does not modify runtime behavior.
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b2389299c8327a1ed496553f0f762)