### PR TITLE
Fix health check tooltip positioning and z-index

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1308,7 +1308,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                                     </div>
                                     {/* Hover tooltip with detailed distribution */}
                                     {totalVotes > 0 && (
-                                      <div className="invisible group-hover/cell:visible absolute left-0 top-full mt-2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px]" style={{ zIndex: 10000 }}>
+                                      <div className="invisible group-hover/cell:visible absolute left-full top-1/2 ml-3 -translate-y-1/2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px] z-50">
                                         <div className="space-y-1.5">
                                           {[5, 4, 3, 2, 1].map(rating => {
                                             const count = distribution[rating] || 0;


### PR DESCRIPTION
### Motivation
- Tooltips for dimension cells were appearing far from the hovered cell and below the table, likely due to positioning and z-index issues.
- The goal is to make the distribution tooltip appear next to the hovered cell and ensure it renders above surrounding containers.

### Description
- Updated the tooltip element in `components/Dashboard.tsx` to use `absolute left-full top-1/2 ml-3 -translate-y-1/2` so it appears to the right of the hovered cell and is vertically centered.
- Replaced the inline `style={{ zIndex: 10000 }}` with the Tailwind utility `z-50` to provide a consistent z-index class.
- Kept `pointer-events-none` and visibility toggling via `group-hover/cell:visible` so the tooltip remains non-interactive and only visible on hover.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite started successfully and served the app.
- Ran a Playwright script to open the app and capture a screenshot which produced the artifact showing the repositioned tooltip.
- A Vite proxy error (`ECONNREFUSED 127.0.0.1:3000`) was observed due to a backend API not running, but the UI loaded and the screenshot was taken successfully.
- No additional automated unit tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2edc536c8327afe02a97492afe27)