### PR TITLE
Fix health check tooltips positioning and z-index

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1246,7 +1246,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                                   {(dim.goodDescription || dim.badDescription) && (
                                     <div className="relative inline-block group/info">
                                       <span className="material-symbols-outlined text-xs text-slate-400 cursor-help hover:text-slate-600">info</span>
-                                      <div className="invisible group-hover/info:visible fixed bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none" style={{ zIndex: 99999, marginLeft: '250px', transform: 'translateY(-50%)' }}>
+                                      <div className="invisible group-hover/info:visible absolute left-full top-1/2 ml-2 -translate-y-1/2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none z-50">
                                         {dim.goodDescription && (
                                           <div className="mb-2 bg-emerald-50 border border-emerald-200 rounded-lg p-2">
                                             <div className="font-bold text-emerald-700 mb-1">Good</div>
@@ -1308,7 +1308,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                                     </div>
                                     {/* Hover tooltip with detailed distribution */}
                                     {totalVotes > 0 && (
-                                      <div className="invisible group-hover/cell:visible absolute left-0 top-full mt-2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px]" style={{ zIndex: 10000 }}>
+                                      <div className="invisible group-hover/cell:visible absolute left-1/2 bottom-full mb-2 -translate-x-1/2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px] z-50">
                                         <div className="space-y-1.5">
                                           {[5, 4, 3, 2, 1].map(rating => {
                                             const count = distribution[rating] || 0;


### PR DESCRIPTION
### Motivation
- Tooltips for health-check dimensions were misaligned and could render outside the table area or underneath other containers, making them hard to read.
- The goal is to align the good/bad info tooltip with its info icon and keep the distribution tooltip visible above the hovered cell.

### Description
- Replaced the info tooltip `fixed`+inline `marginLeft`/`zIndex` approach with local absolute positioning using `absolute left-full top-1/2 ml-2 -translate-y-1/2` and `z-50`.
- Repositioned the distribution tooltip to sit above the hovered cell using `absolute left-1/2 bottom-full mb-2 -translate-x-1/2` and `z-50` to avoid falling below the table.
- Removed inline `style` overrides for `zIndex`/`marginLeft` and consolidated positioning into Tailwind classes while keeping `pointer-events-none` and hover visibility logic.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (success).
- Attempted to run a Playwright script to capture screenshots of both tooltips, but the Playwright run timed out (failed).
- No automated unit tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2edc536c8327afe02a97492afe27)