### PR TITLE
Fix health check tooltip positioning

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1240,13 +1240,13 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                         <tbody>
                           {dimensions.map((dim) => (
                             <tr key={dim.id} className="border-b border-slate-200">
-                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-10">
+                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-30">
                                 <div className="flex items-center gap-1">
                                   <span className="truncate" title={dim.name}>{dim.name}</span>
                                   {(dim.goodDescription || dim.badDescription) && (
                                     <div className="relative inline-block group/info">
                                       <span className="material-symbols-outlined text-xs text-slate-400 cursor-help hover:text-slate-600">info</span>
-                                      <div className="invisible group-hover/info:visible absolute left-full top-0 ml-2 mt-1 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none z-50">
+                                      <div className="invisible group-hover/info:visible absolute left-full top-0 ml-2 mt-1 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none z-[9999]">
                                         {dim.goodDescription && (
                                           <div className="mb-2 bg-emerald-50 border border-emerald-200 rounded-lg p-2">
                                             <div className="font-bold text-emerald-700 mb-1">Good</div>

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1240,7 +1240,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                         <tbody>
                           {dimensions.map((dim) => (
                             <tr key={dim.id} className="border-b border-slate-200">
-                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-30">
+                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-[9999]">
                                 <div className="flex items-center gap-1">
                                   <span className="truncate" title={dim.name}>{dim.name}</span>
                                   {(dim.goodDescription || dim.badDescription) && (

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1246,7 +1246,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                                   {(dim.goodDescription || dim.badDescription) && (
                                     <div className="relative inline-block group/info">
                                       <span className="material-symbols-outlined text-xs text-slate-400 cursor-help hover:text-slate-600">info</span>
-                                      <div className="invisible group-hover/info:visible fixed bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none" style={{ zIndex: 99999, marginLeft: '250px', transform: 'translateY(-50%)' }}>
+                                      <div className="invisible group-hover/info:visible absolute left-full top-0 ml-2 mt-1 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl w-72 pointer-events-none z-50">
                                         {dim.goodDescription && (
                                           <div className="mb-2 bg-emerald-50 border border-emerald-200 rounded-lg p-2">
                                             <div className="font-bold text-emerald-700 mb-1">Good</div>
@@ -1308,7 +1308,7 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                                     </div>
                                     {/* Hover tooltip with detailed distribution */}
                                     {totalVotes > 0 && (
-                                      <div className="invisible group-hover/cell:visible absolute left-0 top-full mt-2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px]" style={{ zIndex: 10000 }}>
+                                      <div className="invisible group-hover/cell:visible absolute left-1/2 bottom-full mb-2 -translate-x-1/2 bg-white border-2 border-slate-300 text-slate-800 text-xs rounded-lg p-3 shadow-2xl pointer-events-none min-w-[200px] z-50">
                                         <div className="space-y-1.5">
                                           {[5, 4, 3, 2, 1].map(rating => {
                                             const count = distribution[rating] || 0;

--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -1239,8 +1239,8 @@ const Dashboard: React.FC<Props> = ({ team, currentUser, onOpenSession, onOpenHe
                         </thead>
                         <tbody>
                           {dimensions.map((dim) => (
-                            <tr key={dim.id} className="border-b border-slate-200">
-                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-[9999]">
+                            <tr key={dim.id} className="border-b border-slate-200 relative z-0 hover:z-[9999]">
+                              <td className="px-3 py-2 text-xs font-medium text-slate-700 sticky left-0 bg-white border-r border-slate-200 w-48 z-30">
                                 <div className="flex items-center gap-1">
                                   <span className="truncate" title={dim.name}>{dim.name}</span>
                                   {(dim.goodDescription || dim.badDescription) && (


### PR DESCRIPTION
### Motivation
- Tooltips for health-check dimensions were rendering in inconsistent positions and could appear underneath other containers or outside the table area.
- The info tooltip should be anchored to the info icon and aligned consistently with it.
- The distribution tooltip should be visible above the hovered cell and horizontally centered over that cell.
- Remove fragile inline `style` positioning to rely on local absolute positioning and Tailwind utilities instead.

### Description
- Replaced the info tooltip `fixed` + inline `style` approach with `absolute left-full top-0 ml-2 mt-1 ... z-50` to anchor it to the icon and align the top edges.
- Repositioned the distribution tooltip from a `top-full` placement with inline `zIndex` to `absolute left-1/2 bottom-full mb-2 -translate-x-1/2 z-50` so it sits centered above the hovered cell.
- Removed inline `style` overrides for `zIndex`, `marginLeft`, and `transform` and consolidated positioning into Tailwind classes while preserving `pointer-events-none` and hover visibility logic.
- Changes made in `components/Dashboard.tsx` where the tooltips are rendered and positioned.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (success).
- Attempted to run a Playwright script to capture tooltip screenshots but the Playwright run timed out (failed).
- No automated unit tests or visual regression tests were run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2edc536c8327afe02a97492afe27)