### PR TITLE
Add manual GHCR deploy workflow

### DIFF
--- a/.github/workflows/deploy-ghcr.yml
+++ b/.github/workflows/deploy-ghcr.yml
@@ -1,0 +1,43 @@
+name: Deploy Docker Image to GHCR
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to publish'
+        required: false
+        default: 'latest'
+
+jobs:
+  deploy:
+    name: Build & Publish Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/retrogemini:${{ inputs.image_tag || 'latest' }}
+            ghcr.io/${{ github.repository_owner }}/retrogemini:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
### Motivation

- Provide a manual way to build and publish the Docker image to GitHub Container Registry so `docker run ... ghcr.io/.../retrogemini:latest` can be used for deployments.
- Allow specifying an image tag at dispatch time to support ad-hoc or versioned publishes via `workflow_dispatch`.

### Description

- Add a new GitHub Actions workflow at ` .github/workflows/deploy-ghcr.yml` that triggers on `workflow_dispatch` with an `image_tag` input defaulting to `latest`.
- The `deploy` job runs on `ubuntu-latest`, sets `contents: read` and `packages: write` permissions, and performs `actions/checkout`, `docker/setup-buildx-action@v3`, and `docker/login-action@v3` using `secrets.GITHUB_TOKEN`.
- The workflow builds and pushes the image using `docker/build-push-action@v5` and tags it as `ghcr.io/${{ github.repository_owner }}/retrogemini:${{ inputs.image_tag || 'latest' }}` and `ghcr.io/${{ github.repository_owner }}/retrogemini:latest`.

### Testing

- No automated tests were run as part of this workflow addition.
- Existing CI workflows (`.github/workflows/ci.yml` and `docker-security.yml`) were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc383d4a88327a22dff8b47f73b61)