### PR TITLE
Fix concurrent group naming and discussion focus issues

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -284,9 +284,9 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
           if (!groupTitleTimersRef.current[groupId]) return; // Timer expired, sync already sent
 
           const group = mergedSession.groups.find(g => g.id === groupId);
-          const prevGroup = prevSession.groups.find(g => g.id === groupId);
-          if (group && prevGroup) {
-            group.title = prevGroup.title;
+          if (group) {
+            // Preserve the LOCAL title being typed, not the old session title
+            group.title = localGroupTitles[groupId];
           }
         });
 

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -278,7 +278,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
         }
 
         // Preserve group titles being edited by current user
+        // Only preserve if timer is still active (user is still typing)
         Object.keys(localGroupTitles).forEach(groupId => {
+          // Check if timer is still active for this group
+          if (!groupTitleTimersRef.current[groupId]) return; // Timer expired, sync already sent
+
           const group = mergedSession.groups.find(g => g.id === groupId);
           const prevGroup = prevSession.groups.find(g => g.id === groupId);
           if (group && prevGroup) {
@@ -494,6 +498,9 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
     // Debounce sync to server (500ms after last keystroke)
     groupTitleTimersRef.current[groupId] = setTimeout(() => {
+      // Remove timer from ref immediately to prevent incorrect preservation
+      delete groupTitleTimersRef.current[groupId];
+
       updateSession(s => {
         const grp = s.groups.find(x => x.id === groupId);
         if (grp) grp.title = title;


### PR DESCRIPTION
This commit fixes two additional concurrency issues in retrospectives:

## 1. Group Naming Concurrency (GROUP phase)
**Problem**: When 2 participants name groups simultaneously, their inputs would interfere with each other, losing characters.

**Solution**:
- Added local state `localGroupTitles` with debouncing (500ms)
- Group title changes sync only after user stops typing
- Preserves group titles being edited during WebSocket updates
- Files: Session.tsx:103-104, 470-493, 1763

**How it works**:
- User types → updates local state immediately (responsive UI)
- After 500ms without input → syncs to server
- On receiving updates → preserves locally edited titles

## 2. Discussion Focus Concurrency (DISCUSS phase) **Problem**: When facilitator clicks to focus on a topic while a participant performs an action, the facilitator's focus change gets cancelled and they must click again.

**Solution**:
- Preserve facilitator's discussion focus during WebSocket updates
- When facilitator changes focus, their change takes precedence
- Files: Session.tsx:289-294

**How it works**:
- When sync update arrives, check if facilitator just changed focus
- If prevSession.discussionFocusId differs from updatedSession, preserve facilitator's local change
- Only facilitator can change focus, so safe to prioritize their state

## Testing:
✅ TypeScript compilation passes
✅ Build successful
✅ All 60 tests pass (4 test suites)
✅ No lint errors (0 errors, warnings only)

## Result:
- Multiple users can name groups simultaneously without conflicts
- Facilitator's discussion focus changes are preserved during concurrent actions
- All text inputs now use debouncing for optimal concurrent editing

All known concurrency issues in Health Checks and Retrospectives resolved.

## Description

<!-- Briefly describe the changes made in this PR -->

## Type of Change

<!-- Check the appropriate boxes by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation changes only)
- [ ] Refactoring (code improvement without changing behavior)
- [ ] Tests (adding or modifying tests)
- [ ] Dependencies (dependency updates)

## Checklist

<!-- Verify you have completed all these steps before submitting the PR -->

- [ ] My code follows the project's style conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] All CI checks pass

## Tests

<!-- Describe the tests you have performed -->

```bash
npm run lint          # ✅ / ❌
npm run type-check    # ✅ / ❌
npm test              # ✅ / ❌
npm run build         # ✅ / ❌
```

## Test Coverage

<!-- If applicable, add coverage information -->

- Coverage before: __%
- Coverage after: __%

## Screenshots / Demo

<!-- If applicable, add screenshots or GIFs to show visual changes -->

## Related Issues

<!-- Reference related issues or PRs -->

Fixes #(issue number)
Relates to #(issue number)

## Additional Notes

<!-- Add any additional information for reviewers -->

## Dependencies

<!-- List all new dependencies added -->

- None
<!-- or -->
<!-- - `package-name@version` - reason for adding -->

## Breaking Changes

<!-- If this PR contains breaking changes, list them here with migration steps -->

- None
<!-- or describe the breaking changes and how to handle them -->

## Deployment Checklist

<!-- For PRs that require special deployment steps -->

- [ ] Environment variables to add/modify
- [ ] Database migration required
- [ ] Deployment documentation updated
- [ ] Changelog updated
