### PR TITLE
Fix concurrent group title editing

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -89,8 +89,13 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // Editing Ticket State
   const [editingTicketId, setEditingTicketId] = useState<string | null>(null);
+  const editingTicketIdRef = useRef<string | null>(null);
   // Editing Group State
   const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const editingGroupIdRef = useRef<string | null>(null);
+
+  useEffect(() => { editingTicketIdRef.current = editingTicketId; }, [editingTicketId]);
+  useEffect(() => { editingGroupIdRef.current = editingGroupId; }, [editingGroupId]);
 
   // Interaction State
   const [emojiPickerOpenId, setEmojiPickerOpenId] = useState<string | null>(null);
@@ -269,18 +274,18 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
         }
 
         // Preserve tickets being edited by current user
-        if (editingTicketId) {
-          const prevTicket = prevSession.tickets.find(t => t.id === editingTicketId);
-          const updatedTicketIndex = mergedSession.tickets.findIndex(t => t.id === editingTicketId);
+        if (editingTicketIdRef.current) {
+          const prevTicket = prevSession.tickets.find(t => t.id === editingTicketIdRef.current);
+          const updatedTicketIndex = mergedSession.tickets.findIndex(t => t.id === editingTicketIdRef.current);
           if (prevTicket && updatedTicketIndex !== -1) {
             mergedSession.tickets[updatedTicketIndex] = { ...mergedSession.tickets[updatedTicketIndex], text: prevTicket.text };
           }
         }
 
         // Preserve group title being edited by current user
-        if (editingGroupId) {
-          const prevGroup = prevSession.groups.find(g => g.id === editingGroupId);
-          const updatedGroupIndex = mergedSession.groups.findIndex(g => g.id === editingGroupId);
+        if (editingGroupIdRef.current) {
+          const prevGroup = prevSession.groups.find(g => g.id === editingGroupIdRef.current);
+          const updatedGroupIndex = mergedSession.groups.findIndex(g => g.id === editingGroupIdRef.current);
           if (prevGroup && updatedGroupIndex !== -1) {
             mergedSession.groups[updatedGroupIndex] = { ...mergedSession.groups[updatedGroupIndex], title: prevGroup.title };
           }

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -89,6 +89,8 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // Editing Ticket State
   const [editingTicketId, setEditingTicketId] = useState<string | null>(null);
+  // Editing Group State
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
 
   // Interaction State
   const [emojiPickerOpenId, setEmojiPickerOpenId] = useState<string | null>(null);
@@ -272,6 +274,15 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
           const updatedTicketIndex = mergedSession.tickets.findIndex(t => t.id === editingTicketId);
           if (prevTicket && updatedTicketIndex !== -1) {
             mergedSession.tickets[updatedTicketIndex] = { ...mergedSession.tickets[updatedTicketIndex], text: prevTicket.text };
+          }
+        }
+
+        // Preserve group title being edited by current user
+        if (editingGroupId) {
+          const prevGroup = prevSession.groups.find(g => g.id === editingGroupId);
+          const updatedGroupIndex = mergedSession.groups.findIndex(g => g.id === editingGroupId);
+          if (prevGroup && updatedGroupIndex !== -1) {
+            mergedSession.groups[updatedGroupIndex] = { ...mergedSession.groups[updatedGroupIndex], title: prevGroup.title };
           }
         }
 
@@ -1730,7 +1741,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
                                                         <input 
                                                             value={g.title} 
                                                             autoFocus={focusGroupId === g.id}
-                                                            onBlur={() => setFocusGroupId(null)}
+                                                            onFocus={() => setEditingGroupId(g.id)}
+                                                            onBlur={() => {
+                                                                setFocusGroupId(null);
+                                                                setEditingGroupId(null);
+                                                            }}
                                                             onKeyDown={(e) => {
                                                                 if(e.key === 'Enter') e.currentTarget.blur();
                                                             }}


### PR DESCRIPTION
### Motivation
- Concurrent edits to group names could be clobbered when remote session updates arrive, causing participants to see truncated or mixed titles.
- The merge strategy already preserves tickets and icebreaker edits, but group title edits were not tracked and thus lost during sync.

### Description
- Added `editingGroupId` state in `components/Session.tsx` to track when the user is editing a group title.
- In the `onSessionUpdate` merge logic (`onSessionUpdate`), preserve the locally edited group's `title` from the previous session when `editingGroupId` is set.
- Start tracking edits with `onFocus` and clear the editing state on `onBlur` of the group title input to avoid clobbering after edit finishes.
- Kept existing preservation behavior for tickets, icebreaker, and vote-related merges (`editingTicketId`, etc.).

### Testing
- No automated tests were run for this change.
- (Manual validation recommended: open two clients, edit different group titles concurrently and verify each client retains their local edit while receiving remote updates.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961268224cc83279d1ddf2232dfe6bd)