### PR TITLE
Fix group drag cancel handling

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -1037,6 +1037,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
             key={t.id}
             draggable={mode === 'GROUP'}
             onDragStart={(e) => handleDragStart(e, t)}
+            onDragEnd={() => resetDragState()}
             onDragOver={(e) => mode === 'GROUP' ? handleDragOverItem(e, t.id) : undefined}
             onDrop={(e) => handleDropOnTicket(e, t)}
             onTouchStart={() => mode === 'GROUP' ? handleTouchStart(t) : undefined}

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -867,6 +867,10 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
           resetDragState();
           return;
       }
+      if (draggedTicket.groupId && draggedTicket.groupId === targetTicket.groupId) {
+          resetDragState();
+          return;
+      }
       if(session.phase !== 'GROUP') return;
 
       updateSession(s => {

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -1649,6 +1649,13 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
                                 ${isColumnDragTarget ? 'border-indigo-500 bg-indigo-50 border-2' : 'border-slate-200'}
                             `}
                             onDragOver={(e) => mode === 'GROUP' ? handleDragOverColumn(e, col.id) : e.preventDefault()}
+                            onDragLeave={(e) => {
+                                if (mode !== 'GROUP') return;
+                                const nextTarget = e.relatedTarget as Node | null;
+                                if (!nextTarget || !e.currentTarget.contains(nextTarget)) {
+                                    setDragTarget(null);
+                                }
+                            }}
                             onDrop={(e) => handleDropOnColumn(e, col.id)}
                         >
                             {/* Explicit Drop Overlay for Columns */}

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -862,7 +862,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   const performDropOnTicket = (targetTicket: Ticket) => {
       setDragTarget(null);
-      if(!draggedTicket || draggedTicket.id === targetTicket.id) return;
+      if(!draggedTicket) return;
+      if (draggedTicket.id === targetTicket.id) {
+          resetDragState();
+          return;
+      }
       if(session.phase !== 'GROUP') return;
 
       updateSession(s => {
@@ -906,6 +910,10 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
   const performDropOnGroup = (targetGroup: Group) => {
       setDragTarget(null);
       if(!draggedTicket) return;
+      if (draggedTicket.groupId === targetGroup.id) {
+          resetDragState();
+          return;
+      }
       if(session.phase !== 'GROUP') return;
 
       updateSession(s => {


### PR DESCRIPTION
### Motivation
- Fix a bug in the GROUP phase where tapping the already-selected card on touch devices would lead to unintended removal instead of cancelling selection.
- Prevent the UI from getting stuck when a card is dragged and dropped onto itself on desktop, requiring another card move to recover.

### Description
- Updated `components/Session.tsx` to bail out and call `resetDragState()` in `performDropOnTicket` when `draggedTicket.id === targetTicket.id` to cancel selection.
- Added a same-target guard in `performDropOnGroup` that calls `resetDragState()` when `draggedTicket.groupId === targetGroup.id` to avoid leaving drag state active. 
- The changes use `performDropOnTicket`, `performDropOnGroup`, and `resetDragState` to ensure drag state is cleared on no-op drops.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696168f1f7c08327b28aabe18aaed5d9)