### PR TITLE
Improve timer end reset and sound

### DIFF
--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -645,7 +645,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
     }
 
     return () => clearInterval(interval);
-  }, [session?.settings.timerRunning, session?.settings.timerStartedAt, session?.settings.timerInitial]);
+  }, [session?.settings.timerRunning, session?.settings.timerStartedAt, session?.settings.timerInitial, session?.settings.timerSeconds]);
 
   if (!session) return <div>Session not found</div>;
   const participants = getParticipants();
@@ -785,7 +785,13 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   const acknowledgeTimer = () => {
       if (sessionRef.current?.settings.timerSeconds === 0 && !sessionRef.current.settings.timerAcknowledged) {
-          updateSession((s) => { s.settings.timerAcknowledged = true; });
+          const timerInitial = sessionRef.current.settings.timerInitial ?? 0;
+          setLocalTimerSeconds(timerInitial);
+          updateSession((s) => {
+              s.settings.timerAcknowledged = true;
+              s.settings.timerSeconds = timerInitial;
+              s.settings.timerStartedAt = undefined;
+          });
       }
   };
 
@@ -1237,7 +1243,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   const renderHeader = () => (
     <header className="h-16 bg-white border-b border-slate-200 flex items-center justify-between px-4 shrink-0 z-50">
-        <audio ref={audioRef} src="https://assets.mixkit.co/active_storage/sfx/2869/2869-preview.mp3" preload="auto" />
+        <audio ref={audioRef} src="https://assets.mixkit.co/active_storage/sfx/933/933-preview.mp3" preload="auto" />
         
         <div className="flex items-center h-full">
             <button onClick={handleExit} className="mr-3 text-slate-400 hover:text-slate-700"><span className="material-symbols-outlined">arrow_back</span></button>

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -131,7 +131,7 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
   const audioRef = useRef<HTMLAudioElement | null>(null);
   useEffect(() => {
     if (audioRef.current) {
-      audioRef.current.volume = 0.5;
+      audioRef.current.volume = 0.3;
     }
   }, []);
 

--- a/components/Session.tsx
+++ b/components/Session.tsx
@@ -129,6 +129,11 @@ const Session: React.FC<Props> = ({ team, currentUser, sessionId, onExit, onTeam
 
   // Audio ref
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  useEffect(() => {
+    if (audioRef.current) {
+      audioRef.current.volume = 0.5;
+    }
+  }, []);
 
   const getAnonymizedLabel = (memberId: string) => {
     if (!session?.settings.isAnonymous) return null;


### PR DESCRIPTION
### Motivation
- When the timer hits zero it produces a loud, strident sound and a bounce animation that can be hard to stop across phase changes. 
- Clicking the timer to stop the animation should also restore the timer to the value it had when started, instead of leaving it at `0:00`.
- The local timer display can become out-of-sync (stuck at `0:00`) when session state changes like phase switches.

### Description
- Keep local display in sync by adding `session?.settings.timerSeconds` to the timer `useEffect` dependency list so `localTimerSeconds` updates when `timerSeconds` changes.
- Update `acknowledgeTimer` so that when `timerSeconds === 0` it resets `localTimerSeconds` and session state back to `timerInitial` and clears `timerStartedAt` to stop the bounce and restore the original value.
- Replace the finish sound URL used by `audioRef` with a softer clip (`https://assets.mixkit.co/active_storage/sfx/933/933-preview.mp3`).

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696175c5a71483278259f68dfbd7e08e)