### PR TITLE
Guard invite auto-join with verified identity checks

### DIFF
--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -64,9 +64,17 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData, onSuperAdminL
     const team = dataService.importTeam(inviteData);
     setSelectedTeam(team);
 
-    // Try to auto-join if we have member name
+    const normalizedInviteEmail = normalizeEmail(inviteData.memberEmail);
+    const canAutoJoin = Boolean(
+      inviteData.memberName &&
+        ((inviteData.memberId && team.members.some((member) => member.id === inviteData.memberId)) ||
+          (inviteData.inviteToken && team.members.some((member) => member.inviteToken === inviteData.inviteToken)) ||
+          (normalizedInviteEmail && team.members.some((member) => normalizeEmail(member.email) === normalizedInviteEmail)))
+    );
+
+    // Try to auto-join only when we can verify identity from invite data
     // The server will validate if email/token authentication is valid
-    if (inviteData.memberName) {
+    if (canAutoJoin && inviteData.memberName) {
       try {
         const { team: updatedTeam, user } = dataService.joinTeamAsParticipant(
           team.id,


### PR DESCRIPTION
### Motivation
- Prevent automatic join attempts from invite links when the invite payload cannot be matched to a known team member to reduce impersonation risk. 
- Address a CI CodeQL security finding by requiring verified identity signals before auto-joining. 
- Preserve existing behavior of showing the join selection UI when auto-join cannot be safely performed. 

### Description
- Added normalization of the invite email via `normalizeEmail` and a `canAutoJoin` guard in `components/TeamLogin.tsx`. 
- `canAutoJoin` verifies at least one identity signal is present and matches a team member (`memberId`, `inviteToken`, or normalized email) before attempting `joinTeamAsParticipant`. 
- Replaced the previous unconditional `inviteData.memberName` auto-join gate with `if (canAutoJoin && inviteData.memberName)` to ensure verification. 
- Retained the existing fallback that sets an error and shows the `JOIN` view when auto-join fails or is not permitted. 

### Testing
- No automated tests were executed for this change. 
- Manual verification: rebuild/run not requested in this patch. 
- Type/system tests: not run. 
- Linting: not executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696625bad470832780f1a8b80c18343c)