### PR TITLE
Use matched member identity for invite auto-join

### DIFF
--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -64,13 +64,20 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData, onSuperAdminL
     const team = dataService.importTeam(inviteData);
     setSelectedTeam(team);
 
-    // Try to auto-join if we have member name
+    const normalizedInviteEmail = normalizeEmail(inviteData.memberEmail);
+    const matchedMember =
+      (inviteData.memberId && team.members.find((member) => member.id === inviteData.memberId)) ||
+      (inviteData.inviteToken && team.members.find((member) => member.inviteToken === inviteData.inviteToken)) ||
+      (normalizedInviteEmail && team.members.find((member) => normalizeEmail(member.email) === normalizedInviteEmail)) ||
+      null;
+
+    // Try to auto-join only when we can verify identity from invite data
     // The server will validate if email/token authentication is valid
-    if (inviteData.memberName) {
+    if (matchedMember) {
       try {
         const { team: updatedTeam, user } = dataService.joinTeamAsParticipant(
           team.id,
-          inviteData.memberName,
+          matchedMember.name,
           inviteData.memberEmail,
           inviteData.inviteToken,
           true


### PR DESCRIPTION
### Motivation
- Prevent impersonation and address a CodeQL security finding by avoiding use of the user-controlled `memberName` when auto-joining from an invite.
- Ensure auto-join only proceeds when invite data can be verified against an existing team member via `memberId`, `inviteToken`, or normalized `memberEmail`.

### Description
- Compute a `matchedMember` by checking `inviteData.memberId`, `inviteData.inviteToken`, and `normalizeEmail(inviteData.memberEmail)` against `team.members`.
- Only attempt `joinTeamAsParticipant` when `matchedMember` is present and pass `matchedMember.name` instead of `inviteData.memberName` to avoid a user-controlled gate.
- Preserve the fallback behavior that sets an error and shows the `JOIN` view if auto-join fails or no match is found.
- Changes made in `components/TeamLogin.tsx` to implement the above logic.

### Testing
- No automated tests were executed for this change.
- No CI, lint, or type/system tests were run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696625bad470832780f1a8b80c18343c)