### PR TITLE
Move invite auto-join verification into data service

### DIFF
--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -64,31 +64,18 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData, onSuperAdminL
     const team = dataService.importTeam(inviteData);
     setSelectedTeam(team);
 
-    // Try to auto-join if we have member name
-    // The server will validate if email/token authentication is valid
-    if (inviteData.memberName) {
-      try {
-        const { team: updatedTeam, user } = dataService.joinTeamAsParticipant(
-          team.id,
-          inviteData.memberName,
-          inviteData.memberEmail,
-          inviteData.inviteToken,
-          true
-        );
-        // Auto-join succeeded (server validated the authentication)
-        if (onJoin) {
-          onJoin(updatedTeam, user);
-        } else {
-          onLogin(updatedTeam);
-        }
-      } catch (err: any) {
-        // Auto-join failed (invalid or missing authentication)
-        // Show member selection screen as fallback
-        setError(err.message);
-        setView('JOIN');
+    try {
+      const { team: updatedTeam, user } = dataService.autoJoinFromInvite(team.id, inviteData);
+      // Auto-join succeeded (server validated the authentication)
+      if (onJoin) {
+        onJoin(updatedTeam, user);
+      } else {
+        onLogin(updatedTeam);
       }
-    } else {
-      // No member name provided - show member selection screen
+    } catch (err: any) {
+      // Auto-join failed (invalid or missing authentication)
+      // Show member selection screen as fallback
+      setError(err.message);
       setView('JOIN');
     }
   }, [inviteData, onJoin, onLogin]);


### PR DESCRIPTION
### Motivation
- Prevent impersonation by avoiding use of user-controlled `memberName` when auto-joining from an invite.
- Centralize invite verification logic to ensure the same identity checks are applied server-side in the data layer.
- Simplify the client invite flow so it only calls a verified helper and preserves the fallback join UI.

### Description
- Add `dataService.autoJoinFromInvite` which matches an invite to an existing member by `memberId`, `inviteToken`, or normalized `memberEmail` and throws if no match is found.
- Have `autoJoinFromInvite` call `joinTeamAsParticipant` with the verified `matchedMember.name` and pass through `memberEmail` and `inviteToken`.
- Replace the inline auto-join logic in `components/TeamLogin.tsx` with a single call to `dataService.autoJoinFromInvite` and preserve the error/fallback behavior that shows the `JOIN` view.
- Keep existing protections in `joinTeamAsParticipant` (email normalization, facilitator name blocking, and invite/token handling) intact.

### Testing
- No automated tests were executed for this change.
- No CI, lint, or type/system tests were run as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696625bad470832780f1a8b80c18343c)