### PR TITLE
Introduce InviteAutoJoinError and suppress generic invite verification message

### DIFF
--- a/components/TeamLogin.tsx
+++ b/components/TeamLogin.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { dataService } from '../services/dataService';
+import { dataService, InviteAutoJoinError } from '../services/dataService';
 import { Team, User, RetroSession, ActionItem } from '../types';
 
 export interface InviteData {
@@ -75,7 +75,12 @@ const TeamLogin: React.FC<Props> = ({ onLogin, onJoin, inviteData, onSuperAdminL
     } catch (err: any) {
       // Auto-join failed (invalid or missing authentication)
       // Show member selection screen as fallback
-      setError(err.message);
+      if (err instanceof InviteAutoJoinError && err.code === 'INVITE_NOT_VERIFIED') {
+        setError('');
+      } else {
+        const message = err instanceof Error ? err.message : String(err);
+        setError(message);
+      }
       setView('JOIN');
     }
   }, [inviteData, onJoin, onLogin]);

--- a/services/dataService.ts
+++ b/services/dataService.ts
@@ -7,6 +7,16 @@ let hydratedFromServer = false;
 let hydrateInFlight: Promise<void> | null = null;
 let dataCache: { teams: Team[] } = { teams: [] };
 
+export class InviteAutoJoinError extends Error {
+  code: 'INVITE_NOT_VERIFIED';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'InviteAutoJoinError';
+    this.code = 'INVITE_NOT_VERIFIED';
+  }
+}
+
 const getHex = (twClass: string) => {
     if(twClass.includes('emerald')) return '#10B981';
     if(twClass.includes('rose')) return '#F43F5E';
@@ -917,7 +927,7 @@ export const dataService = {
       null;
 
     if (!matchedMember) {
-      throw new Error('Invitation could not be verified. Please join manually.');
+      throw new InviteAutoJoinError('Invitation could not be verified. Please join manually.');
     }
 
     return dataService.joinTeamAsParticipant(


### PR DESCRIPTION
### Motivation
- Prevent showing a confusing generic message when invite auto-join should gracefully fall back to manual join. 
- Replace a fragile magic-string check with a typed error so the UI can distinguish expected verification fallbacks from real failures. 

### Description
- Add a new exported `InviteAutoJoinError` class in `services/dataService.ts` to represent unverified invite auto-join attempts. 
- Change `autoJoinFromInvite` to throw `InviteAutoJoinError` instead of a generic `Error` with a magic string. 
- Update `components/TeamLogin.tsx` to import `InviteAutoJoinError` and suppress the visible error when the thrown error is an `InviteAutoJoinError`, falling back to the `JOIN` view. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696645c64e788327b3f22258f97dd831)