### PR TITLE
Add manual GitHub Actions workflow to build and push Docker image to Docker Hub

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to publish'
+        required: true
+        default: '0.1'
+
+jobs:
+  dockerhub-deploy:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_REPOSITORY }}:${{ inputs.image_tag }}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ docker-compose up -d app
 
 Data is automatically persisted in a Docker volume named `retro-data`.
 
+### GitHub Actions (Docker Hub Manual Deploy)
+
+To publish a Docker image to Docker Hub from GitHub Actions, configure the following
+repository secrets and manually run the workflow:
+
+1. Add secrets in **Settings → Secrets and variables → Actions**:
+   - `DOCKERHUB_USERNAME`: your Docker Hub username
+   - `DOCKERHUB_TOKEN`: a Docker Hub access token
+   - `DOCKERHUB_REPOSITORY`: the full repository name (e.g. `your-org/retrogemini`)
+2. Open **Actions → Deploy Docker Image → Run workflow** and provide an `image_tag`
+   (defaults to `0.1`).
+
+The workflow builds from `Dockerfile` and pushes the image to Docker Hub under
+`DOCKERHUB_REPOSITORY:image_tag`.
+
 ### Kubernetes / OpenShift
 
 The `k8s/` directory contains Kustomize manifests with automatic PVC creation:


### PR DESCRIPTION
### Motivation
- Provide a manual deployment job to publish the application's Docker image to Docker Hub from the repository. 
- Allow selecting the published image tag at runtime with a sensible default of `0.1` for quick test deployments. 
- Reuse the repository `Dockerfile` to ensure the pushed image matches the built artifact. 

### Description
- Add ` .github/workflows/docker-deploy.yml` which defines a `workflow_dispatch` workflow with an `image_tag` input defaulting to `0.1`. 
- The job `dockerhub-deploy` checks out the code, sets up Docker Buildx, logs into Docker Hub using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets, and builds+pushes the image. 
- The image is pushed using `docker/build-push-action@v6` with the tag taken from the supplied `image_tag` and repository from `DOCKERHUB_REPOSITORY`. 
- The workflow uses the repository `Dockerfile` (`./Dockerfile`) and sets `permissions: contents: read` for the job. 

### Testing
- No automated tests were executed for this change because it only adds a CI workflow file and does not modify application code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966496100ac832782a7e25c3bd9ea2c)