### PR TITLE
Document SUPER_ADMIN_PASSWORD in README, .env.example, and docker-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,9 @@
 # Security Configuration (Optional)
 # =============================================================================
 
+# Password to enable super admin panel and API endpoints (disabled if unset)
+# SUPER_ADMIN_PASSWORD=change-me
+
 # Restrict WebSocket CORS to specific origin(s)
 # Default: "*" (allow all origins - suitable for self-hosted deployments)
 # For production behind a known domain, set to your application URL

--- a/README.md
+++ b/README.md
@@ -118,6 +118,31 @@ All configuration is via environment variables. See [`.env.example`](.env.exampl
 | `SMTP_USER` | SMTP username | _(none)_ |
 | `SMTP_PASS` | SMTP password | _(none)_ |
 | `FROM_EMAIL` | Sender email address | `SMTP_USER` |
+| `SUPER_ADMIN_PASSWORD` | Enables the super admin panel when set | _(disabled)_ |
+
+### Super Admin Panel
+
+Set `SUPER_ADMIN_PASSWORD` to enable the super admin panel and API endpoints. This is disabled by default.
+
+**Docker run example:**
+
+```bash
+docker run -d \
+  --name retrogemini \
+  -p 8080:8080 \
+  -v /path/to/data:/data \
+  -e SUPER_ADMIN_PASSWORD='change-me' \
+  retrogemini
+```
+
+**Docker Compose example:**
+
+```yaml
+services:
+  app:
+    environment:
+      SUPER_ADMIN_PASSWORD: "change-me"
+```
 
 ### Data Persistence
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       # - SMTP_PASS=your-password
       # - FROM_EMAIL=noreply@example.com
       #
+      # Optional: Super admin panel
+      # - SUPER_ADMIN_PASSWORD=change-me
+      #
       # Optional: Corporate proxy support
       # - HTTP_PROXY=http://proxy.example.com:8080
       # - HTTPS_PROXY=http://proxy.example.com:8080


### PR DESCRIPTION
### Motivation

- Expose and document the `SUPER_ADMIN_PASSWORD` opt-in so operators can enable the super admin panel securely via an environment variable.
- Ensure the Docker Compose configuration also surfaces the option for production deployments as requested during the docker-compose review.

### Description

- Add `SUPER_ADMIN_PASSWORD` to the README configuration table and a new "Super Admin Panel" section with `docker run` and Docker Compose examples.
- Add a commented `SUPER_ADMIN_PASSWORD` entry to `.env.example` and a commented hint for `SUPER_ADMIN_PASSWORD` in `docker-compose.yml`.

### Testing

- No automated tests were run and CI was not exercised because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966574e8f048327aa414a6867683fdd)