### PR TITLE
fix: persist e2e videos and upload unified artifact

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,19 +35,13 @@ jobs:
           echo '== test-results videos =='
           find test-results -type f -name '*.webm' | sort || true
 
-      - name: Upload Playwright HTML report
+      - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-
-      - name: Upload Playwright videos
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: playwright-videos
-          path: test-results/**/*.webm
+          name: playwright-artifacts
+          path: |
+            playwright-report/
+            test-results/
           if-no-files-found: warn
           retention-days: 30

--- a/e2e/retro-full-flow.spec.ts
+++ b/e2e/retro-full-flow.spec.ts
@@ -29,15 +29,23 @@ test.describe('Full Retrospective Flow', () => {
   let participant: Page;
 
   test.beforeAll(async ({ browser }) => {
-    facilitatorContext = await browser.newContext();
-    participantContext = await browser.newContext();
+    facilitatorContext = await browser.newContext({
+      recordVideo: {
+        dir: 'test-results/videos/facilitator',
+      },
+    });
+    participantContext = await browser.newContext({
+      recordVideo: {
+        dir: 'test-results/videos/participant',
+      },
+    });
     facilitator = await facilitatorContext.newPage();
     participant = await participantContext.newPage();
   });
 
   test.afterAll(async () => {
-    await facilitatorContext.close();
-    await participantContext.close();
+    await facilitatorContext?.close();
+    await participantContext?.close();
   });
 
   test('Complete retro session with facilitator and participant', async () => {


### PR DESCRIPTION
### Motivation
- Playwright videos were not always produced in CI because the test creates browser contexts with `browser.newContext()` which does not automatically pick up the global `use.video` option. 
- GitHub Actions uploaded report and videos into separate artifacts which is inconvenient for debugging and retrieval.

### Description
- Explicitly enable video recording for the two test contexts by passing `recordVideo.dir` to `browser.newContext()` in `e2e/retro-full-flow.spec.ts`. 
- Make `afterAll` teardown robust by using optional chaining when closing contexts (`await facilitatorContext?.close()` and `await participantContext?.close()`).
- Replace two separate artifact uploads in `.github/workflows/e2e.yml` with a single `playwright-artifacts` upload that includes both `playwright-report/` and `test-results/` so HTML report and `.webm` videos are archived together.

### Testing
- Ran full CI checks with `npm run ci` which completed successfully (lint warnings only). 
- Installed Playwright browsers with `npx playwright install --with-deps chromium` and retried E2E; `npm run test:e2e` passed and produced `test-results/**/*.webm`. 
- Ran coverage with `npm run test:coverage` which completed successfully and reported coverage. 
- Ran production audit `npm audit --omit=dev --audit-level=high` which reported no high vulnerabilities.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a01cf3f8ac8327b0d0cdcc2b769249)